### PR TITLE
feat: render view fills viewport with fixed-size test mode

### DIFF
--- a/app/(render)/render/[activityId]/RenderClient.tsx
+++ b/app/(render)/render/[activityId]/RenderClient.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import { ActivityData } from '@/lib/types';
 import PhotoBadge from '@/app/components/PhotoBadge';
@@ -22,11 +23,25 @@ const ActivityMap = dynamic(() => import('@/app/components/ActivityMap'), {
 
 interface RenderClientProps {
   activity: ActivityData;
-  width: number;
-  height: number;
+  width?: number;
+  height?: number;
 }
 
-export default function RenderClient({ activity, width, height }: RenderClientProps) {
+export default function RenderClient({ activity, width: fixedWidth, height: fixedHeight }: RenderClientProps) {
+  const [viewportSize, setViewportSize] = useState({ w: fixedWidth ?? 0, h: fixedHeight ?? 0 });
+
+  useEffect(() => {
+    if (fixedWidth && fixedHeight) return;
+    const update = () => setViewportSize({ w: window.innerWidth, h: window.innerHeight });
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, [fixedWidth, fixedHeight]);
+
+  const width = fixedWidth ?? viewportSize.w;
+  const height = fixedHeight ?? viewportSize.h;
+
+  if (!width || !height) return null;
   const hasPhotos = activity.photos.length > 0;
 
   if (!hasPhotos) {
@@ -34,7 +49,7 @@ export default function RenderClient({ activity, width, height }: RenderClientPr
   }
 
   const columnCount = activity.photos.length <= 3 ? 1 : 2;
-  const galleryRatio = columnCount === 1 ? 0.2 : 0.4;
+  const galleryRatio = columnCount === 1 ? 0.25 : 0.4;
   const galleryWidth = Math.round(width * galleryRatio);
 
   return (

--- a/app/(render)/render/[activityId]/page.tsx
+++ b/app/(render)/render/[activityId]/page.tsx
@@ -3,15 +3,16 @@ import RenderClient from './RenderClient';
 
 interface RenderPageProps {
   params: Promise<{ activityId: string }>;
-  searchParams: Promise<{ width?: string; height?: string; token?: string }>;
+  searchParams: Promise<{ width?: string; height?: string; fixed?: string; token?: string }>;
 }
 
 export default async function RenderPage({ params, searchParams }: RenderPageProps) {
   const { activityId } = await params;
-  const { width: widthParam, height: heightParam, token } = await searchParams;
+  const { width: widthParam, height: heightParam, fixed, token } = await searchParams;
 
-  const width = parseInt(widthParam || '1200', 10);
-  const height = parseInt(heightParam || '630', 10);
+  const useFixedSize = fixed === 'true';
+  const fixedWidth = useFixedSize ? parseInt(widthParam || '1720', 10) : undefined;
+  const fixedHeight = useFixedSize ? parseInt(heightParam || '1080', 10) : undefined;
 
   if (!token && !activityId.startsWith('mock-')) {
     return <div>Missing access token</div>;
@@ -20,8 +21,12 @@ export default async function RenderPage({ params, searchParams }: RenderPagePro
   const activity = await getActivityDetail(token || '', activityId);
 
   return (
-    <div style={{ width, height, overflow: 'hidden' }}>
-      <RenderClient activity={activity} width={width} height={height} />
+    <div style={{
+      width: fixedWidth ?? '100vw',
+      height: fixedHeight ?? '100vh',
+      overflow: 'hidden',
+    }}>
+      <RenderClient activity={activity} width={fixedWidth} height={fixedHeight} />
     </div>
   );
 }

--- a/app/api/activity-printout/route.ts
+++ b/app/api/activity-printout/route.ts
@@ -54,7 +54,7 @@ export async function GET(request: NextRequest) {
     const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
     const bypassParam = bypassSecret ? `&x-vercel-protection-bypass=${bypassSecret}&x-vercel-set-bypass-cookie=samesitenone` : '';
     const token = encodeURIComponent(session.accessToken);
-    const renderUrl = `${origin}/render/${activityId}?width=${width}&height=${height}&token=${token}${bypassParam}`;
+    const renderUrl = `${origin}/render/${activityId}?token=${token}${bypassParam}`;
 
     await page.goto(renderUrl, {
       waitUntil: 'networkidle0',

--- a/app/components/PhotoGallery.tsx
+++ b/app/components/PhotoGallery.tsx
@@ -33,7 +33,7 @@ export default function PhotoGallery({ photos, activeIndex, columnCount = 2 }: P
           key={photo.id}
           ref={(el) => { itemRefs.current[index] = el; }}
           className="relative break-inside-avoid"
-          style={{ marginBottom: 4 }}
+          style={{ marginBottom: index < photos.length - 1 ? 4 : 0 }}
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img


### PR DESCRIPTION
## Summary
- Render page now fills `100vw`/`100vh` by default instead of requiring width/height query params — Puppeteer's `setViewport()` controls the screenshot dimensions
- Added `?fixed=true` query param that locks to 1720x1080 (overridable with `&width=X&height=Y`) for easy browser testing
- Removed width/height params from the Puppeteer render URL since the viewport handles sizing
- Fixed bottom margin gap on last photo in the main activity view gallery

## Why
The render page was using fixed pixel dimensions from query params, meaning it didn't adapt when opened directly in a browser. For the screenshot pipeline, Puppeteer already controls the viewport size, so the page just needs to fill it. The `?fixed=true` param preserves a quick way to test at the default screenshot dimensions.

## Test plan
- [ ] `/render/mock-gallery` — fills browser viewport, resizes with window
- [ ] `/render/mock-gallery?fixed=true` — fixed 1720x1080
- [ ] `/render/mock-gallery?fixed=true&width=1920&height=1200` — custom fixed size
- [ ] Screenshot download still works via the API route

🤖 Generated with [Claude Code](https://claude.com/claude-code)