### PR TITLE
feat: earthy olive green colour scheme with design tokens

### DIFF
--- a/app/(main)/activity/[id]/ActivityViewClient.tsx
+++ b/app/(main)/activity/[id]/ActivityViewClient.tsx
@@ -111,8 +111,8 @@ export default function ActivityViewClient({ activity }: ActivityViewClientProps
   }, []);
 
   const spinner = (
-    <div className="absolute inset-0 z-10 flex items-center justify-center bg-zinc-100 dark:bg-zinc-900">
-      <svg className="h-8 w-8 animate-spin text-zinc-400" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <div className="absolute inset-0 z-10 flex items-center justify-center bg-surface-muted">
+      <svg className="h-8 w-8 animate-spin text-text-tertiary" viewBox="0 0 24 24" fill="none" aria-hidden="true">
         <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
         <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
       </svg>
@@ -131,7 +131,7 @@ export default function ActivityViewClient({ activity }: ActivityViewClientProps
   }
 
   return (
-    <div ref={containerRef} className="relative w-full bg-zinc-100 dark:bg-zinc-900">
+    <div ref={containerRef} className="relative w-full bg-surface-muted">
       {dimensions && (
         <div
           className={isWide ? 'flex flex-row items-stretch gap-1' : 'flex flex-col gap-1'}

--- a/app/(main)/activity/[id]/page.tsx
+++ b/app/(main)/activity/[id]/page.tsx
@@ -30,23 +30,23 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
   }
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-black">
+    <div className="min-h-screen bg-surface">
       <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 sm:py-8">
         <div className="mb-3 flex items-center justify-between sm:mb-6">
           <div>
             <Link
               href="/"
-              className="text-sm font-medium text-zinc-600 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-300"
+              className="text-sm font-medium text-primary hover:text-primary-light transition-colors"
             >
               &larr; Back to activities
             </Link>
-            <h1 className="mt-1 text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+            <h1 className="mt-1 text-xl font-semibold text-text-primary">
               {activity.name}
             </h1>
           </div>
           <DownloadButton activityId={id} />
         </div>
-        <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700">
+        <div className="overflow-hidden rounded-lg border border-border">
           <ActivityViewClient activity={activity} />
         </div>
       </div>

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -7,22 +7,22 @@ export default async function Home() {
   const isLoggedIn = !!session.accessToken;
 
   return (
-    <div className="flex min-h-screen items-start justify-center bg-zinc-50 font-sans dark:bg-black">
+    <div className="flex min-h-screen items-start justify-center bg-surface font-sans">
       <main className="w-full max-w-4xl px-4 py-8 sm:px-6 sm:py-12">
         {isLoggedIn ? (
           <>
             <div className="mb-8 flex flex-wrap items-center justify-between gap-2">
-              <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">
+              <h1 className="text-2xl font-semibold text-text-primary">
                 Activities
               </h1>
               <div className="flex items-center gap-4">
-                <span className="text-sm text-zinc-500 dark:text-zinc-400">
+                <span className="text-sm text-text-secondary">
                   {session.athlete?.firstname} {session.athlete?.lastname}
                 </span>
-                <form action="/api/auth/logout" method="POST" className="inline">
+                <form action="/api/auth/logout" method="POST" className="contents">
                   <button
                     type="submit"
-                    className="text-sm font-medium text-zinc-600 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-300"
+                    className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
                   >
                     Log out
                   </button>
@@ -33,10 +33,10 @@ export default async function Home() {
           </>
         ) : (
           <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6">
-            <h1 className="text-3xl font-semibold text-zinc-900 dark:text-zinc-100">
+            <h1 className="text-3xl font-semibold text-text-primary">
               Plot
             </h1>
-            <p className="text-lg text-zinc-600 dark:text-zinc-400">
+            <p className="text-lg text-text-secondary">
               Generate printout screenshots of your Strava activities
             </p>
             <LoginButton />

--- a/app/(render)/render/[activityId]/RenderClient.tsx
+++ b/app/(render)/render/[activityId]/RenderClient.tsx
@@ -14,7 +14,7 @@ const ActivityMap = dynamic(() => import('@/app/components/ActivityMap'), {
       justifyContent: 'center',
       width: '100%',
       height: '100%',
-      background: '#f0f0f0',
+      background: '#FFF8EC',
     }}>
       Loading map...
     </div>
@@ -84,8 +84,8 @@ export default function RenderClient({ activity, width: fixedWidth, height: fixe
               marginBottom: 8,
               borderRadius: 4,
               overflow: 'hidden',
-              border: '1px solid #333333',
-              boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+              border: '2px solid #5C5C50',
+              boxShadow: '0 2px 8px rgba(44,44,36,0.18)',
             }}
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/app/components/ActivityList.tsx
+++ b/app/components/ActivityList.tsx
@@ -88,7 +88,7 @@ export default function ActivityList() {
   }, [page]);
 
   if (loading) {
-    return <p className="text-zinc-500">Loading activities...</p>;
+    return <p className="text-text-secondary">Loading activities...</p>;
   }
 
   if (error) {
@@ -96,7 +96,7 @@ export default function ActivityList() {
   }
 
   if (activities.length === 0 && page === 1) {
-    return <p className="text-zinc-500">No activities found.</p>;
+    return <p className="text-text-secondary">No activities found.</p>;
   }
 
   return (
@@ -104,7 +104,7 @@ export default function ActivityList() {
       <div className="overflow-x-auto">
         <table className="w-full text-left text-sm">
           <thead>
-            <tr className="border-b border-zinc-200 text-xs font-medium uppercase tracking-wider text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">
+            <tr className="border-b border-border text-xs font-medium uppercase tracking-wider text-text-tertiary">
               {/* Mobile: combined column */}
               <th scope="col" className="px-2 py-1.5 sm:hidden">Activity</th>
               {/* Desktop: separate columns */}
@@ -121,38 +121,38 @@ export default function ActivityList() {
             {activities.map((a) => (
               <tr
                 key={a.id}
-                className="border-b border-zinc-100 dark:border-zinc-800"
+                className="border-b border-border"
               >
                 {/* Mobile: stacked cell */}
                 <td className="px-2 py-1.5 sm:hidden">
-                  <div className="font-medium text-zinc-900 dark:text-zinc-100">{a.name}</div>
-                  <div className="text-xs text-zinc-500 dark:text-zinc-400">
+                  <div className="font-medium text-text-primary">{a.name}</div>
+                  <div className="text-xs text-text-secondary">
                     {formatDate(a.startDate)} · {formatDistance(a.distance)}
                   </div>
                 </td>
                 {/* Desktop: separate cells */}
-                <td className="hidden whitespace-nowrap px-3 py-2 text-zinc-500 sm:table-cell dark:text-zinc-400">
+                <td className="hidden whitespace-nowrap px-3 py-2 text-text-secondary sm:table-cell">
                   {formatDate(a.startDate)}
                 </td>
-                <td className="hidden px-3 py-2 font-medium text-zinc-900 sm:table-cell dark:text-zinc-100">
+                <td className="hidden px-3 py-2 font-medium text-text-primary sm:table-cell">
                   {a.name}
                 </td>
-                <td className="hidden px-3 py-2 text-zinc-500 sm:table-cell dark:text-zinc-400">
+                <td className="hidden px-3 py-2 text-text-secondary sm:table-cell">
                   {a.type}
                 </td>
-                <td className="hidden whitespace-nowrap px-3 py-2 text-right text-zinc-700 sm:table-cell dark:text-zinc-300">
+                <td className="hidden whitespace-nowrap px-3 py-2 text-right text-text-secondary sm:table-cell">
                   {formatDistance(a.distance)}
                 </td>
-                <td className="whitespace-nowrap px-2 py-1.5 text-right text-zinc-700 sm:px-3 sm:py-2 dark:text-zinc-300">
+                <td className="whitespace-nowrap px-2 py-1.5 text-right text-text-secondary sm:px-3 sm:py-2">
                   {formatDuration(a.movingTime)}
                 </td>
-                <td className="hidden whitespace-nowrap px-3 py-2 text-right text-zinc-700 sm:table-cell dark:text-zinc-300">
+                <td className="hidden whitespace-nowrap px-3 py-2 text-right text-text-secondary sm:table-cell">
                   {a.elevationGain.toFixed(0)}m
                 </td>
                 <td className="whitespace-nowrap px-2 py-1.5 text-right sm:px-3 sm:py-2">
                   <Link
                     href={`/activity/${a.id}`}
-                    className="mr-2 text-sm font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                    className="mr-2 text-sm font-medium text-primary hover:text-primary-light transition-colors"
                   >
                     View
                   </Link>
@@ -161,7 +161,7 @@ export default function ActivityList() {
                     onClick={() => handleDownload(a.id)}
                     disabled={downloading.has(a.id)}
                     aria-busy={downloading.has(a.id)}
-                    className="inline-flex items-center gap-1 text-sm font-medium text-zinc-600 hover:text-zinc-800 disabled:opacity-50 dark:text-zinc-400 dark:hover:text-zinc-300"
+                    className="inline-flex items-center gap-1 text-sm font-medium text-text-secondary hover:text-text-primary disabled:opacity-50 transition-colors"
                   >
                     {downloading.has(a.id) && (
                       <svg className="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -182,17 +182,17 @@ export default function ActivityList() {
         <button
           onClick={() => { setLoading(true); setPage((p) => Math.max(1, p - 1)); }}
           disabled={loading || page === 1}
-          className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-600 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          className="rounded-md border border-border px-3 py-1.5 text-sm font-medium text-text-primary transition-colors hover:bg-surface-muted disabled:cursor-not-allowed disabled:opacity-50"
         >
           Previous
         </button>
-        <span className="text-sm text-zinc-500 dark:text-zinc-400">
+        <span className="text-sm text-text-secondary">
           Page {page}
         </span>
         <button
           onClick={() => { setLoading(true); setPage((p) => p + 1); }}
           disabled={loading || !hasMore}
-          className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-600 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          className="rounded-md border border-border px-3 py-1.5 text-sm font-medium text-text-primary transition-colors hover:bg-surface-muted disabled:cursor-not-allowed disabled:opacity-50"
         >
           Next
         </button>

--- a/app/components/ActivityMap.tsx
+++ b/app/components/ActivityMap.tsx
@@ -47,7 +47,7 @@ function RouteOutlineFilter() {
       // Find the route polyline by stroke color
       const paths = svg.querySelectorAll('path.leaflet-interactive');
       const routePath = Array.from(paths).find(
-        (p) => p.getAttribute('stroke') === '#080357'
+        (p) => p.getAttribute('stroke') === '#4A5A2B'
       );
       if (!routePath) return;
 
@@ -70,7 +70,7 @@ function RouteOutlineFilter() {
           '  <feFuncA type="linear" slope="100" intercept="0"/>',
           '</feComponentTransfer>',
           '<feMorphology in="opaque-alpha" operator="dilate" radius="2" result="dilated"/>',
-          '<feFlood flood-color="#333333" flood-opacity="0.9" result="color"/>',
+          '<feFlood flood-color="#3A4722" flood-opacity="0.85" result="color"/>',
           '<feComposite in="color" in2="dilated" operator="in" result="full-outline"/>',
           // Subtract original stroke area so outline only appears outside
           '<feComposite in="full-outline" in2="opaque-alpha" operator="out" result="border-only"/>',
@@ -164,7 +164,7 @@ export default function ActivityMap({ activity, width, height, paddingRight = 0,
     : [54.4, -2.9];
 
   return (
-    <div style={{ width, height, position: 'relative' }}>
+    <div style={{ width, height, position: 'relative', colorScheme: 'only light' }}>
       <MapContainer
         center={center}
         zoom={7}
@@ -183,9 +183,9 @@ export default function ActivityMap({ activity, width, height, paddingRight = 0,
         <Polyline
           positions={route}
           pathOptions={{
-            color: '#080357',
-            weight: 4,
-            opacity: 0.2,
+            color: '#4A5A2B',
+            weight: 5,
+            opacity: 0.35,
           }}
         />
         <RouteOutlineFilter />

--- a/app/components/DownloadButton.tsx
+++ b/app/components/DownloadButton.tsx
@@ -38,7 +38,7 @@ export default function DownloadButton({ activityId }: DownloadButtonProps) {
       onClick={handleDownload}
       disabled={loading}
       aria-busy={loading}
-      className="inline-flex items-center gap-2 rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-60 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300"
+      className="inline-flex items-center gap-2 rounded-md bg-primary dark:bg-primary-dark px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-dark dark:hover:bg-primary disabled:opacity-60"
     >
       {loading && (
         <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">

--- a/app/components/PhotoBadge.tsx
+++ b/app/components/PhotoBadge.tsx
@@ -15,12 +15,12 @@ export default function PhotoBadge({ number }: PhotoBadgeProps) {
         alignItems: 'center',
         justifyContent: 'center',
         borderRadius: '50%',
-        background: 'rgba(8, 3, 87, 0.75)',
-        border: '2px solid rgba(51, 51, 51, 0.9)',
+        background: 'rgba(74, 90, 43, 0.82)',
+        border: '2px solid rgba(58, 71, 34, 0.9)',
         fontSize: 11,
         fontWeight: 700,
         color: 'white',
-        boxShadow: '0 2px 6px rgba(0,0,0,0.3)',
+        boxShadow: '0 2px 6px rgba(44,44,36,0.3)',
       }}
     >
       {number}

--- a/app/components/PhotoOverlay.tsx
+++ b/app/components/PhotoOverlay.tsx
@@ -19,8 +19,8 @@ function createNumberedIcon(number: number) {
     html: `<div style="
       width: 28px;
       height: 28px;
-      background: rgba(8, 3, 87, 0.75);
-      border: 2px solid rgba(51, 51, 51, 0.9);
+      background: rgba(74, 90, 43, 0.82);
+      border: 2px solid rgba(58, 71, 34, 0.9);
       border-radius: 50%;
       display: flex;
       align-items: center;
@@ -28,7 +28,7 @@ function createNumberedIcon(number: number) {
       font-size: 13px;
       font-weight: 700;
       color: white;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+      box-shadow: 0 2px 6px rgba(44,44,36,0.3);
       cursor: pointer;
     ">${number}</div>`,
     iconSize: [28, 28],
@@ -55,8 +55,8 @@ export default function PhotoOverlay({ photos, onPinClick }: PhotoOverlayProps) 
             min-width: 34px;
             width: ${width}px;
             height: 34px;
-            background: rgba(8, 3, 87, 0.75);
-            border: 2px solid rgba(51, 51, 51, 0.9);
+            background: rgba(74, 90, 43, 0.82);
+            border: 2px solid rgba(58, 71, 34, 0.9);
             border-radius: 17px;
             display: flex;
             align-items: center;
@@ -64,7 +64,7 @@ export default function PhotoOverlay({ photos, onPinClick }: PhotoOverlayProps) 
             font-size: 12px;
             font-weight: 600;
             color: white;
-            box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+            box-shadow: 0 2px 6px rgba(44,44,36,0.3);
             padding: 0 4px;
             white-space: nowrap;
           ">${label}</div>`,

--- a/app/components/TextOverlay.tsx
+++ b/app/components/TextOverlay.tsx
@@ -50,9 +50,9 @@ export default function TextOverlay({ activity }: TextOverlayProps) {
         bottom: 0,
         left: 0,
         right: 0,
-        background: 'linear-gradient(transparent, rgba(8,3,87,0.75))',
-        color: 'white',
-        padding: '40px 20px 20px',
+        background: 'linear-gradient(to bottom, transparent 0%, rgba(255,248,236,0.5) 40%, rgba(255,248,236,0.88) 100%)',
+        color: '#1C1814',
+        padding: '60px 24px 20px',
         zIndex: 1000,
       }}
     >
@@ -61,7 +61,8 @@ export default function TextOverlay({ activity }: TextOverlayProps) {
           margin: '0 0 8px',
           fontSize: '24px',
           fontWeight: 'bold',
-          textShadow: '0 1px 3px rgba(0,0,0,0.5)',
+          letterSpacing: '-0.01em',
+          textShadow: '0 1px 2px rgba(255,248,236,0.6)',
         }}
       >
         {activity.name}
@@ -69,8 +70,8 @@ export default function TextOverlay({ activity }: TextOverlayProps) {
       <p
         style={{
           margin: '0 0 12px',
-          fontSize: '14px',
-          opacity: 0.9,
+          fontSize: '13px',
+          fontWeight: 400,
         }}
       >
         {formatDate(activity.stats.startDate)}
@@ -83,28 +84,28 @@ export default function TextOverlay({ activity }: TextOverlayProps) {
         }}
       >
         <div>
-          <div style={{ fontSize: '20px', fontWeight: 'bold' }}>
+          <div style={{ fontSize: '20px', fontWeight: 'bold', letterSpacing: '-0.02em' }}>
             {formatDistance(activity.stats.distance)}
           </div>
-          <div style={{ fontSize: '12px', opacity: 0.8 }}>Distance</div>
+          <div style={{ fontSize: '13px', fontWeight: 400 }}>Distance</div>
         </div>
         <div>
-          <div style={{ fontSize: '20px', fontWeight: 'bold' }}>
+          <div style={{ fontSize: '20px', fontWeight: 'bold', letterSpacing: '-0.02em' }}>
             {formatDuration(activity.stats.movingTime)}
           </div>
-          <div style={{ fontSize: '12px', opacity: 0.8 }}>Time</div>
+          <div style={{ fontSize: '13px', fontWeight: 400 }}>Time</div>
         </div>
         <div>
-          <div style={{ fontSize: '20px', fontWeight: 'bold' }}>
+          <div style={{ fontSize: '20px', fontWeight: 'bold', letterSpacing: '-0.02em' }}>
             {formatPace(activity.stats.averageSpeed)}
           </div>
-          <div style={{ fontSize: '12px', opacity: 0.8 }}>Pace</div>
+          <div style={{ fontSize: '13px', fontWeight: 400 }}>Pace</div>
         </div>
         <div>
-          <div style={{ fontSize: '20px', fontWeight: 'bold' }}>
+          <div style={{ fontSize: '20px', fontWeight: 'bold', letterSpacing: '-0.02em' }}>
             {activity.stats.elevationGain} m
           </div>
-          <div style={{ fontSize: '12px', opacity: 0.8 }}>Elevation</div>
+          <div style={{ fontSize: '13px', fontWeight: 400 }}>Elevation</div>
         </div>
       </div>
     </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,26 +1,88 @@
 @import "tailwindcss";
 
+/* ===== Light Mode Tokens ===== */
+/* Inspired by Ordnance Survey maps: footpath green (#01A751) and contour orange (#F78F47) */
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #FFF8EC;
+  --foreground: #1C1814;
+
+  --surface: #FFF8EC;
+  --surface-raised: #FFFFFF;
+  --surface-muted: #F5E2C6;
+
+  --border: #E8CCA8;
+  --border-strong: #D4B696;
+
+  --text-primary: #1C1814;
+  --text-secondary: #4D463D;
+  --text-tertiary: #7A7168;
+
+  --primary: #4A5A2B;
+  --primary-light: #6B7F3F;
+  --primary-lighter: #8FA45A;
+  --primary-dark: #3A4722;
+
+  --accent: #D4872B;
+  --accent-light: #E09B45;
 }
 
+/* ===== Dark Mode Tokens ===== */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #1C1008;
+    --foreground: #F0ECE6;
+
+    --surface: #1C1008;
+    --surface-raised: #2A1810;
+    --surface-muted: #382414;
+
+    --border: #4A3420;
+    --border-strong: #604830;
+
+    --text-primary: #F0ECE6;
+    --text-secondary: #C0B8AC;
+    --text-tertiary: #8E857A;
+
+    --primary: #A3B86E;
+    --primary-light: #B8CC83;
+    --primary-lighter: #CDDF9C;
+    --primary-dark: #8FA45A;
+
+    --accent: #E09B45;
+    --accent-light: #EBAF62;
+  }
+}
+
+/* ===== Tailwind Theme Integration ===== */
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-surface: var(--surface);
+  --color-surface-raised: var(--surface-raised);
+  --color-surface-muted: var(--surface-muted);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-text-primary: var(--text-primary);
+  --color-text-secondary: var(--text-secondary);
+  --color-text-tertiary: var(--text-tertiary);
+  --color-primary: var(--primary);
+  --color-primary-light: var(--primary-light);
+  --color-primary-lighter: var(--primary-lighter);
+  --color-primary-dark: var(--primary-dark);
+  --color-accent: var(--accent);
+  --color-accent-light: var(--accent-light);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+/* Pin map rendering to light mode so dark mode never affects route line, pins, or overlay */
+.leaflet-container {
+  color-scheme: only light;
+  color: #1C1814;
 }


### PR DESCRIPTION
## Summary

- Introduces a CSS custom property design token system in `globals.css` with automatic light/dark mode switching, replacing all hardcoded `zinc-*` and `dark:zinc-*` Tailwind classes
- Olive green primary palette (#4A5A2B) inspired by OS map footpath green, with warm orange-tinted backgrounds inspired by OS contour lines
- Redesigned map text overlay from white-on-purple gradient to dark text on light cream gradient, with map rendering pinned to light mode via `color-scheme: only light` so it looks identical regardless of system theme
- Updated all map components (route line, pins, photo badges, photo frame borders) to use the olive green palette with warm-tinted shadows

Resolves #6

## Test plan

- [ ] Verify light mode: warm orange background, olive green links/buttons, readable table text
- [ ] Verify dark mode: dark orange background, bright green links, map overlay unchanged from light mode
- [ ] Check activity detail page: back link, download button, map rendering
- [ ] Generate a screenshot via download button to verify render pipeline (text overlay, route colour, pins)
- [ ] Check mobile responsiveness of activity list table

🤖 Generated with [Claude Code](https://claude.com/claude-code)