### PR TITLE
feat: redesign photo gallery layout in renderer view

### DIFF
--- a/app/(main)/activity/[id]/page.tsx
+++ b/app/(main)/activity/[id]/page.tsx
@@ -1,20 +1,26 @@
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { getSession } from '@/lib/auth';
-import { getActivityDetail } from '@/lib/strava';
+import { getActivityDetail, MockOrientation } from '@/lib/strava';
 import ActivityViewClient from './ActivityViewClient';
 import DownloadButton from '@/app/components/DownloadButton';
 
 interface ActivityPageProps {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ photos?: string; orientation?: string }>;
 }
 
-export default async function ActivityPage({ params }: ActivityPageProps) {
+export default async function ActivityPage({ params, searchParams }: ActivityPageProps) {
   const { id } = await params;
+  const { photos, orientation } = await searchParams;
 
   let activity;
-  if (id.startsWith('mock-')) {
-    activity = await getActivityDetail('', id);
+  if (id === 'mock') {
+    const mockOptions = {
+      photos: photos ? parseInt(photos, 10) : undefined,
+      orientation: (['landscape', 'portrait', 'mixed'].includes(orientation ?? '') ? orientation : undefined) as MockOrientation | undefined,
+    };
+    activity = await getActivityDetail('', id, mockOptions);
   } else {
     const session = await getSession();
 

--- a/app/(render)/render/[activityId]/RenderClient.tsx
+++ b/app/(render)/render/[activityId]/RenderClient.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import { ActivityData } from '@/lib/types';
-import PhotoBadge from '@/app/components/PhotoBadge';
 
 const ActivityMap = dynamic(() => import('@/app/components/ActivityMap'), {
   ssr: false,
@@ -27,6 +26,24 @@ interface RenderClientProps {
   height?: number;
 }
 
+function getGalleryLayout(photoCount: number) {
+  if (photoCount === 0) return null;
+
+  if (photoCount <= 2) {
+    return { columns: 1 as const, galleryRatio: 0.4 };
+  }
+
+  if (photoCount === 3) {
+    return { columns: 1 as const, galleryRatio: 0.27 };
+  }
+
+  if (photoCount === 4) {
+    return { columns: 1 as const, galleryRatio: 0.2 };
+  }
+
+  return { columns: 2 as const, galleryRatio: 0.38 };
+}
+
 export default function RenderClient({ activity, width: fixedWidth, height: fixedHeight }: RenderClientProps) {
   const [viewportSize, setViewportSize] = useState({ w: fixedWidth ?? 0, h: fixedHeight ?? 0 });
 
@@ -42,15 +59,19 @@ export default function RenderClient({ activity, width: fixedWidth, height: fixe
   const height = fixedHeight ?? viewportSize.h;
 
   if (!width || !height) return null;
-  const hasPhotos = activity.photos.length > 0;
 
-  if (!hasPhotos) {
+  const layout = getGalleryLayout(activity.photos.length);
+
+  if (!layout) {
     return <ActivityMap activity={activity} width={width} height={height} />;
   }
 
-  const columnCount = activity.photos.length <= 3 ? 1 : 2;
-  const galleryRatio = columnCount === 1 ? 0.25 : 0.4;
+  const displayPhotos = activity.photos.slice(0, 8);
+  const isSinglePhoto = displayPhotos.length === 1;
+  const { columns, galleryRatio } = layout;
   const galleryWidth = Math.round(width * galleryRatio);
+
+  const itemGap = 4;
 
   return (
     <div style={{ width, height, position: 'relative' }}>
@@ -69,34 +90,70 @@ export default function RenderClient({ activity, width: fixedWidth, height: fixe
           height,
           zIndex: 1000,
           overflow: 'hidden',
-          columns: columnCount,
-          columnFill: 'auto' as const,
-          columnGap: 8,
-          padding: 8,
+          background: 'linear-gradient(to right, transparent 0%, rgba(255,248,236,0.15) 20%, rgba(255,248,236,0.3) 100%)',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '8px 16px 8px 8px',
         }}
       >
-        {activity.photos.map((photo, index) => (
-          <div
-            key={photo.id}
-            style={{
-              position: 'relative',
-              breakInside: 'avoid',
-              marginBottom: 8,
-              borderRadius: 4,
-              overflow: 'hidden',
-              border: '2px solid #5C5C50',
-              boxShadow: '0 2px 8px rgba(44,44,36,0.18)',
-            }}
-          >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={photo.url}
-              alt={photo.caption || `Photo ${index + 1}`}
-              style={{ display: 'block', width: '100%' }}
-            />
-            <PhotoBadge number={index + 1} />
-          </div>
-        ))}
+        <div
+          style={{
+            display: 'flex',
+            ...(columns === 1
+              ? { flexDirection: 'column' as const }
+              : { flexDirection: 'row' as const, flexWrap: 'wrap' as const, alignContent: 'center' as const }),
+            justifyContent: 'center',
+            gap: itemGap,
+          }}
+        >
+          {displayPhotos.map((photo, index) => (
+            <div
+              key={photo.id}
+              style={{
+                padding: 4,
+                background: 'rgba(255,248,236,0.6)',
+                borderRadius: 4,
+                ...(columns === 2 ? { width: `calc(50% - ${itemGap / 2}px)` } : {}),
+              }}
+            >
+              <div
+                style={{
+                  borderRadius: 2,
+                  overflow: 'hidden',
+                  boxShadow: '0 2px 8px rgba(44,44,36,0.18)',
+                }}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={photo.url}
+                  alt={photo.caption || `Photo ${index + 1}`}
+                  style={{
+                    display: 'block',
+                    width: '100%',
+                    ...(isSinglePhoto
+                      ? {}
+                      : { aspectRatio: '4 / 3', objectFit: 'cover' as const }),
+                  }}
+                />
+              </div>
+              <span
+                style={{
+                  position: 'relative',
+                  zIndex: 1,
+                  display: 'block',
+                  marginTop: 2,
+                  fontSize: 10,
+                  fontWeight: 600,
+                  color: '#4A5A2B',
+                  lineHeight: 1,
+                }}
+              >
+                {index + 1}
+              </span>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/app/(render)/render/[activityId]/page.tsx
+++ b/app/(render)/render/[activityId]/page.tsx
@@ -1,24 +1,29 @@
-import { getActivityDetail } from '@/lib/strava';
+import { getActivityDetail, MockOrientation } from '@/lib/strava';
 import RenderClient from './RenderClient';
 
 interface RenderPageProps {
   params: Promise<{ activityId: string }>;
-  searchParams: Promise<{ width?: string; height?: string; fixed?: string; token?: string }>;
+  searchParams: Promise<{ width?: string; height?: string; fixed?: string; token?: string; photos?: string; orientation?: string }>;
 }
 
 export default async function RenderPage({ params, searchParams }: RenderPageProps) {
   const { activityId } = await params;
-  const { width: widthParam, height: heightParam, fixed, token } = await searchParams;
+  const { width: widthParam, height: heightParam, fixed, token, photos, orientation } = await searchParams;
 
   const useFixedSize = fixed === 'true';
   const fixedWidth = useFixedSize ? parseInt(widthParam || '860', 10) : undefined;
   const fixedHeight = useFixedSize ? parseInt(heightParam || '540', 10) : undefined;
 
-  if (!token && !activityId.startsWith('mock-')) {
+  if (!token && activityId !== 'mock') {
     return <div>Missing access token</div>;
   }
 
-  const activity = await getActivityDetail(token || '', activityId);
+  const mockOptions = activityId === 'mock' ? {
+    photos: photos ? parseInt(photos, 10) : undefined,
+    orientation: (['landscape', 'portrait', 'mixed'].includes(orientation ?? '') ? orientation : undefined) as MockOrientation | undefined,
+  } : undefined;
+
+  const activity = await getActivityDetail(token || '', activityId, mockOptions);
 
   return (
     <div style={{

--- a/app/components/PhotoBadge.tsx
+++ b/app/components/PhotoBadge.tsx
@@ -1,29 +1,29 @@
 interface PhotoBadgeProps {
   number: number;
+  size?: number;
 }
 
-export default function PhotoBadge({ number }: PhotoBadgeProps) {
+export default function PhotoBadge({ number, size = 22 }: PhotoBadgeProps) {
+  const fontSize = size <= 18 ? 9 : 11;
   return (
     <div
       style={{
-        position: 'absolute',
-        left: 6,
-        top: 6,
-        width: 22,
-        height: 22,
+        width: size,
+        height: size,
+        flexShrink: 0,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
         borderRadius: '50%',
         background: 'rgba(74, 90, 43, 0.82)',
         border: '2px solid rgba(58, 71, 34, 0.9)',
-        fontSize: 11,
+        fontSize,
         fontWeight: 700,
         color: 'white',
         boxShadow: '0 2px 6px rgba(44,44,36,0.3)',
       }}
     >
-      <span style={{ fontSize: 11 }}>{number}</span>
+      <span style={{ fontSize }}>{number}</span>
     </div>
   );
 }

--- a/app/components/PhotoGallery.tsx
+++ b/app/components/PhotoGallery.tsx
@@ -43,7 +43,9 @@ export default function PhotoGallery({ photos, activeIndex, columnCount = 2 }: P
                 alt={photo.caption || `Photo ${index + 1}`}
                 className="block w-full"
               />
-              <PhotoBadge number={index + 1} />
+              <div style={{ position: 'absolute', left: 6, top: 6 }}>
+                <PhotoBadge number={index + 1} />
+              </div>
             </div>
           </div>
         );


### PR DESCRIPTION
## Summary

- Replaces the CSS columns gallery layout with flexbox, with layout tiers based on photo count: wide single column (1-2), medium (3), narrow (4), and two-column (5-8)
- Images now display at fixed 4:3 aspect ratio with `object-fit: cover` cropping, except single photos which preserve their original aspect ratio
- Number badges replaced with small text labels below each image; cream semi-transparent backdrop behind each photo card
- Gallery capped at 8 photos (remaining photos still visible as map pins)
- Mock data consolidated to a single parameterised URL: `/render/mock?photos=N&orientation=portrait|landscape|mixed`
- PhotoBadge component generalised (positioning removed, size prop added); PhotoGallery updated to wrap badge in positioned container

Closes #23

## Test plan

- [ ] Visit `/render/mock?photos=1&orientation=portrait&fixed=true` — single photo, original aspect ratio preserved
- [ ] Visit `/render/mock?photos=2&orientation=mixed&fixed=true` — wide single column
- [ ] Visit `/render/mock?photos=3&orientation=mixed&fixed=true` — medium single column, 4:3 crop
- [ ] Visit `/render/mock?photos=4&orientation=mixed&fixed=true` — narrow single column
- [ ] Visit `/render/mock?photos=6&orientation=mixed&fixed=true` — two-column layout
- [ ] Visit `/render/mock?photos=8&orientation=portrait&fixed=true` — two-column, all fit without clipping
- [ ] Verify interactive activity view (`/activity/[id]`) still shows overlaid photo badges correctly
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)