### PR TITLE
feat: planner UX improvements for mobile and touch

### DIFF
--- a/app/(main)/planner/PlannerClient.tsx
+++ b/app/(main)/planner/PlannerClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useEffect, useCallback, useMemo } from 'react';
+import { useRef, useState, useEffect, useCallback, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import type Map from 'ol/Map';
 import { fromLonLat } from 'ol/proj';
@@ -15,6 +15,7 @@ const PlannerMap = dynamic(() => import('./PlannerMap'), { ssr: false });
 
 export default function PlannerClient() {
   const { waypoints, canUndo, canRedo, dispatch } = useRouteHistory();
+  const [addPointsEnabled, setAddPointsEnabled] = useState(false);
   const mapInstanceRef = useRef<Map | null>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -83,6 +84,7 @@ export default function PlannerClient() {
         waypoints={waypoints}
         dispatch={dispatch}
         onMapReady={handleMapReady}
+        addPointsEnabled={addPointsEnabled}
       />
       <PlannerToolbar
         waypoints={waypoints}
@@ -91,6 +93,8 @@ export default function PlannerClient() {
         canRedo={canRedo}
         dispatch={dispatch}
         onGeolocate={handleGeolocate}
+        addPointsEnabled={addPointsEnabled}
+        onToggleAddPoints={() => setAddPointsEnabled((v) => !v)}
       />
     </div>
   );

--- a/app/(main)/planner/PlannerToolbar.tsx
+++ b/app/(main)/planner/PlannerToolbar.tsx
@@ -12,6 +12,8 @@ interface PlannerToolbarProps {
   canRedo: boolean;
   dispatch: React.Dispatch<RouteAction>;
   onGeolocate: () => void;
+  addPointsEnabled: boolean;
+  onToggleAddPoints: () => void;
 }
 
 function formatDistance(meters: number): string {
@@ -29,6 +31,8 @@ export default function PlannerToolbar({
   canRedo,
   dispatch,
   onGeolocate,
+  addPointsEnabled,
+  onToggleAddPoints,
 }: PlannerToolbarProps) {
   const handleUndo = useCallback(() => dispatch({ type: 'UNDO' }), [dispatch]);
   const handleRedo = useCallback(() => dispatch({ type: 'REDO' }), [dispatch]);
@@ -47,9 +51,30 @@ export default function PlannerToolbar({
 
   return (
     <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1 bg-surface-raised/95 backdrop-blur-sm rounded-xl shadow-lg border border-border px-2 py-1.5 sm:gap-2 sm:px-3 sm:py-2">
+      {/* Add-points toggle */}
+      <button
+        onClick={onToggleAddPoints}
+        title={addPointsEnabled ? 'Disable add mode' : 'Enable add mode'}
+        className={`flex items-center justify-center w-11 h-11 rounded-lg transition-colors ${
+          addPointsEnabled
+            ? 'bg-accent-light/20 text-accent'
+            : 'text-text-primary hover:bg-surface-muted'
+        }`}
+      >
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="8" x2="12" y2="16" />
+          <line x1="8" y1="12" x2="16" y2="12" />
+        </svg>
+      </button>
+
       {/* Distance display — hidden on very small screens */}
       <div className="hidden sm:block text-text-primary font-medium text-sm whitespace-nowrap px-2">
-        {distance > 0 ? formatDistance(distance) : 'Click map to start'}
+        {distance > 0
+          ? formatDistance(distance)
+          : addPointsEnabled
+            ? 'Click map to start'
+            : 'Click + to start'}
       </div>
       {/* Compact distance for mobile */}
       <div className="sm:hidden text-text-primary font-medium text-xs whitespace-nowrap px-1">

--- a/app/globals.css
+++ b/app/globals.css
@@ -86,3 +86,34 @@ body {
   color-scheme: only light;
   color: #1C1814;
 }
+
+/* Delete waypoint popup (imperative DOM, outside React) */
+.ol-delete-popup {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  padding: 4px;
+}
+
+.ol-delete-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 6px;
+  background: #fee2e2;
+  color: #b91c1c;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.ol-delete-btn:hover {
+  background: #fca5a5;
+}
+
+.ol-delete-btn:active {
+  background: #f87171;
+  color: #fff;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,15 @@ const nextConfig: NextConfig = {
   outputFileTracingIncludes: {
     '/api/activity-printout': ['./node_modules/@sparticuz/chromium/bin/**'],
   },
+  async redirects() {
+    return [
+      {
+        source: '/plan',
+        destination: '/planner',
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Addresses touch/UX issues with the route planner before it's production-ready on mobile:

- **Add-points toggle**: Off by default — tapping the map no longer accidentally adds waypoints while panning. Toggle button in the toolbar with a soft orange highlight when active, crosshair cursor when enabled
- **Delete popup**: Replaces instant-delete on right-click (desktop) and long-press (mobile) with a confirmation popup overlay containing a trash button
- **Touch line-drag disabled**: Dragging the route line on touch devices no longer inserts points (was interfering with panning). Desktop drag-to-insert still works. Dragging existing waypoint markers works on both
- **Haptic feedback**: Subtle vibration on add (15ms), long-press popup (40ms), delete confirm (30ms), and line-drag insert (15ms)
- **Tile layer improvements**: 1:25k tiles now stay visible at further-out zoom levels via upscaling, with OS overview tiles at mid-zoom and an OSM base layer for very low zooms
- **`/plan` → `/planner` redirect**: Permanent redirect for the old URL

Closes #27

## Test plan

- [ ] Desktop: toggle off → clicks don't add points, can pan freely. Toggle on → clicks add. Click waypoint → delete popup. Right-click waypoint → delete popup. Drag line → inserts point
- [ ] Mobile: toggle off → taps don't add, can pan. Toggle on → taps add. Long-press waypoint → popup with delete. Drag on route line → pans map (no point inserted). Drag waypoint marker → still works
- [ ] `/plan` redirects to `/planner`
- [ ] Zoom out far → transitions from 1:25k → OS overview → OSM

🤖 Generated with [Claude Code](https://claude.com/claude-code)