### PR TITLE
feat: route planner touch UX and pin markers

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -109,11 +109,54 @@ body {
   transition: background 0.15s;
 }
 
-.ol-delete-btn:hover {
-  background: #fca5a5;
+@media (hover: hover) {
+  .ol-delete-btn:hover {
+    background: #fca5a5;
+  }
 }
 
 .ol-delete-btn:active {
   background: #f87171;
   color: #fff;
+}
+
+.ol-delete-btn:focus {
+  outline: none;
+}
+
+/* Insert waypoint popup (imperative DOM, outside React) */
+.ol-insert-popup {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  padding: 4px;
+}
+
+.ol-insert-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 6px;
+  background: #dcfce7;
+  color: var(--primary-dark, #3A4722);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+@media (hover: hover) {
+  .ol-insert-btn:hover {
+    background: #bbf7d0;
+  }
+}
+
+.ol-insert-btn:active {
+  background: #86efac;
+  color: #fff;
+}
+
+.ol-insert-btn:focus {
+  outline: none;
 }


### PR DESCRIPTION
## Summary

Follow-up UX fixes for the route planner after #28, plus a visual refresh replacing circle markers with pin-shaped markers.

- **Pin markers**: SVG pin shape with numbered head, tip anchored on the route line. Slightly translucent so the map shows through. Hover/drag indicator is a pin-shaped outline instead of a circle.
- **Touch: insert waypoint**: Tapping the route line on mobile shows an insert popup with a + button (since drag-to-insert is mouse-only). Finds the nearest segment and inserts at the correct index.
- **Touch: delete guard**: Tapping a waypoint no longer immediately shows the delete popup — long-press only on mobile. Desktop click/right-click unchanged.
- **Touch: no route drag-to-insert**: `routeModify` condition blocks touch pointer type to prevent accidental inserts while panning.
- **Touch: no sticky focus/hover**: Hover styles wrapped in `@media (hover: hover)`, focus outlines removed on popup buttons.
- **Live line during drag**: Line follows waypoint position in real-time during drag via geometry change listener. Delete popup also tracks if open.

## Why

Touch interactions from #28 needed refinement — delete popup appeared too eagerly on tap, no way to add points along the route on mobile, line didn't update live during drag, and hover/focus states persisted after touch.

## Test plan

- [ ] Desktop: click waypoint → delete popup. Right-click → delete popup. Hover pin → move cursor + pin outline. Hover line → copy cursor + snap circle. Drag waypoint → line follows live.
- [ ] Mobile: tap waypoint → nothing. Long-press → haptic + delete popup. Tap route line → insert popup. Tap + → inserts waypoint. No sticky hover/focus after tap.
- [ ] Pin numbers visible and centered in pin head

🤖 Generated with [Claude Code](https://claude.com/claude-code)