### PR TITLE
feat(auth): gate premium features via backend athlete allowlist

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { getSession } from '@/lib/auth';
 import { getAthleteActivities, StravaApiError } from '@/lib/strava';
+import { hasPremium } from '@/lib/entitlements';
 import MapShell, { type PanelMode } from '@/app/components/shell/MapShell';
 import { ActivitySummary } from '@/lib/types';
 
@@ -38,15 +39,14 @@ export default async function Home({ searchParams }: { searchParams: Promise<{ m
     ? `${session.athlete.firstname?.[0] ?? ''}${session.athlete.lastname?.[0] ?? ''}`
     : '?';
 
-  const tilesAthleteId = process.env.TILES_ATHLETE_ID;
-  const isOwner = !!tilesAthleteId && !!session.athlete && String(session.athlete.id) === tilesAthleteId;
+  const isPremium = hasPremium(session);
 
   return (
     <MapShell
       activities={activities}
       avatarInitials={avatarInitials}
       isLoggedIn={isLoggedIn}
-      isOwner={isOwner}
+      isPremium={isPremium}
       initialMode={initialMode}
       initialSelectedId={initialSelectedId}
       authError={authError}

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSession } from '@/lib/auth';
+import { bootstrapPremiumAccess, type StravaTokenResponse } from '@/lib/backend';
 
 export async function GET(request: NextRequest) {
   const code = request.nextUrl.searchParams.get('code');
@@ -38,7 +39,7 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const data = await tokenRes.json();
+  const data: StravaTokenResponse = await tokenRes.json();
 
   session.accessToken = data.access_token;
   session.refreshToken = data.refresh_token;
@@ -48,6 +49,9 @@ export async function GET(request: NextRequest) {
     firstname: data.athlete.firstname,
     lastname: data.athlete.lastname,
   };
+  // Best-effort: onboards the athlete into the backend and resolves premium
+  // feature access once, cached in the session for the rest of this login.
+  session.entitlements = { premium: await bootstrapPremiumAccess(data) };
   await session.save();
 
   return NextResponse.redirect(new URL('/', request.nextUrl.origin));

--- a/app/api/explorer/route.ts
+++ b/app/api/explorer/route.ts
@@ -1,27 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSession } from '@/lib/auth';
+import { getPremiumBackendConfig } from '@/lib/backend';
 
 export async function GET(request: NextRequest) {
   const session = await getSession();
-  const tilesAthleteId = process.env.TILES_ATHLETE_ID;
-  const tilesBackendUrl = process.env.TILES_BACKEND_URL;
-  const tilesBearerToken = process.env.TILES_BEARER_TOKEN;
+  const backend = getPremiumBackendConfig(session);
 
-  if (!tilesAthleteId || !tilesBackendUrl || !tilesBearerToken) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  }
-
-  if (String(session.athlete?.id) !== tilesAthleteId) {
+  if (!backend) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
 
   const filter = request.nextUrl.searchParams.get('filter') || 'all';
 
   try {
-    const res = await fetch(`${tilesBackendUrl}/explorer?filter=${encodeURIComponent(filter)}`, {
+    const res = await fetch(`${backend.url}/explorer?filter=${encodeURIComponent(filter)}`, {
       headers: {
-        Authorization: `Bearer ${tilesBearerToken}`,
-        'X-Athlete-Id': String(session.athlete!.id),
+        Authorization: `Bearer ${backend.token}`,
+        'X-Athlete-Id': backend.athleteId,
       },
     });
     const data = await res.json();

--- a/app/api/photos/import/route.ts
+++ b/app/api/photos/import/route.ts
@@ -1,17 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSession } from '@/lib/auth';
+import { getPremiumBackendConfig } from '@/lib/backend';
 
 export async function POST(request: NextRequest) {
   const session = await getSession();
-  const tilesAthleteId = process.env.TILES_ATHLETE_ID;
-  const tilesBackendUrl = process.env.TILES_BACKEND_URL;
-  const tilesBearerToken = process.env.TILES_BEARER_TOKEN;
+  const backend = getPremiumBackendConfig(session);
 
-  if (!tilesAthleteId || !tilesBackendUrl || !tilesBearerToken) {
-    return new NextResponse(null, { status: 404 });
-  }
-
-  if (String(session.athlete?.id) !== tilesAthleteId) {
+  if (!backend) {
     return new NextResponse(null, { status: 404 });
   }
 
@@ -23,11 +18,11 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const res = await fetch(`${tilesBackendUrl}/photos/import`, {
+    const res = await fetch(`${backend.url}/photos/import`, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${tilesBearerToken}`,
-        'X-Athlete-Id': tilesAthleteId,
+        Authorization: `Bearer ${backend.token}`,
+        'X-Athlete-Id': backend.athleteId,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(body),

--- a/app/api/photos/route.ts
+++ b/app/api/photos/route.ts
@@ -1,23 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSession } from '@/lib/auth';
+import { getPremiumBackendConfig } from '@/lib/backend';
 
 export async function GET(request: NextRequest) {
   const session = await getSession();
-  const tilesAthleteId = process.env.TILES_ATHLETE_ID;
-  const tilesBackendUrl = process.env.TILES_BACKEND_URL;
-  const tilesBearerToken = process.env.TILES_BEARER_TOKEN;
+  const backend = getPremiumBackendConfig(session);
 
-  if (!tilesAthleteId || !tilesBackendUrl || !tilesBearerToken) {
-    return new NextResponse(null, { status: 404 });
-  }
-
-  if (String(session.athlete?.id) !== tilesAthleteId) {
+  if (!backend) {
     return new NextResponse(null, { status: 404 });
   }
 
   // Forward all provided query params to the backend unchanged.
   // When no bbox params are given the backend returns all photos (for client-side clustering).
-  const backendUrl = new URL(`${tilesBackendUrl}/photos`);
+  const backendUrl = new URL(`${backend.url}/photos`);
   new URL(request.url).searchParams.forEach((value, key) => {
     backendUrl.searchParams.set(key, value);
   });
@@ -25,8 +20,8 @@ export async function GET(request: NextRequest) {
   try {
     const res = await fetch(backendUrl.toString(), {
       headers: {
-        Authorization: `Bearer ${tilesBearerToken}`,
-        'X-Athlete-Id': tilesAthleteId,
+        Authorization: `Bearer ${backend.token}`,
+        'X-Athlete-Id': backend.athleteId,
       },
     });
 

--- a/app/api/tiles/[z]/[x]/[y]/route.ts
+++ b/app/api/tiles/[z]/[x]/[y]/route.ts
@@ -1,30 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSession } from '@/lib/auth';
+import { getPremiumBackendConfig } from '@/lib/backend';
 
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ z: string; x: string; y: string }> }
 ) {
   const session = await getSession();
-  const tilesAthleteId = process.env.TILES_ATHLETE_ID;
-  const tilesBackendUrl = process.env.TILES_BACKEND_URL;
-  const tilesBearerToken = process.env.TILES_BEARER_TOKEN;
+  const backend = getPremiumBackendConfig(session);
 
-  if (!tilesAthleteId || !tilesBackendUrl || !tilesBearerToken) {
-    return new NextResponse(null, { status: 404 });
-  }
-
-  if (String(session.athlete?.id) !== tilesAthleteId) {
+  if (!backend) {
     return new NextResponse(null, { status: 404 });
   }
 
   const { z, x, y } = await params;
 
   try {
-    const res = await fetch(`${tilesBackendUrl}/tiles/${z}/${x}/${y}`, {
+    const res = await fetch(`${backend.url}/tiles/${z}/${x}/${y}`, {
       headers: {
-        Authorization: `Bearer ${tilesBearerToken}`,
-        'X-Athlete-Id': String(session.athlete!.id),
+        Authorization: `Bearer ${backend.token}`,
+        'X-Athlete-Id': backend.athleteId,
       },
     });
 

--- a/app/api/tiles/activities/route.ts
+++ b/app/api/tiles/activities/route.ts
@@ -1,17 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSession } from '@/lib/auth';
+import { getPremiumBackendConfig } from '@/lib/backend';
 
 export async function GET(request: NextRequest) {
   const session = await getSession();
-  const tilesAthleteId = process.env.TILES_ATHLETE_ID;
-  const tilesBackendUrl = process.env.TILES_BACKEND_URL;
-  const tilesBearerToken = process.env.TILES_BEARER_TOKEN;
+  const backend = getPremiumBackendConfig(session);
 
-  if (!tilesAthleteId || !tilesBackendUrl || !tilesBearerToken) {
-    return new NextResponse(null, { status: 404 });
-  }
-
-  if (String(session.athlete?.id) !== tilesAthleteId) {
+  if (!backend) {
     return new NextResponse(null, { status: 404 });
   }
 
@@ -24,10 +19,10 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const res = await fetch(`${tilesBackendUrl}/tiles/activities?lat=${lat}&lng=${lng}`, {
+    const res = await fetch(`${backend.url}/tiles/activities?lat=${lat}&lng=${lng}`, {
       headers: {
-        Authorization: `Bearer ${tilesBearerToken}`,
-        'X-Athlete-Id': String(session.athlete!.id),
+        Authorization: `Bearer ${backend.token}`,
+        'X-Athlete-Id': backend.athleteId,
       },
     });
 

--- a/app/api/tiles/meta/route.ts
+++ b/app/api/tiles/meta/route.ts
@@ -1,25 +1,20 @@
 import { NextResponse } from 'next/server';
 import { getSession } from '@/lib/auth';
+import { getPremiumBackendConfig } from '@/lib/backend';
 
 export async function GET() {
   const session = await getSession();
-  const tilesAthleteId = process.env.TILES_ATHLETE_ID;
-  const tilesBackendUrl = process.env.TILES_BACKEND_URL;
-  const tilesBearerToken = process.env.TILES_BEARER_TOKEN;
+  const backend = getPremiumBackendConfig(session);
 
-  if (!tilesAthleteId || !tilesBackendUrl || !tilesBearerToken) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  }
-
-  if (String(session.athlete?.id) !== tilesAthleteId) {
+  if (!backend) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
 
   try {
-    const res = await fetch(`${tilesBackendUrl}/tiles/meta`, {
+    const res = await fetch(`${backend.url}/tiles/meta`, {
       headers: {
-        Authorization: `Bearer ${tilesBearerToken}`,
-        'X-Athlete-Id': String(session.athlete!.id),
+        Authorization: `Bearer ${backend.token}`,
+        'X-Athlete-Id': backend.athleteId,
       },
     });
     const data = await res.json();

--- a/app/components/shell/LayersPanel.tsx
+++ b/app/components/shell/LayersPanel.tsx
@@ -74,7 +74,7 @@ interface LayersPanelProps {
   bottom?: number;
   fixed?: boolean;
   forceOpen?: boolean;
-  isOwner?: boolean;
+  isPremium?: boolean;
   theme?: Theme;
   onThemeChange?: (t: Theme) => void;
   triggerStyle?: React.CSSProperties;
@@ -130,7 +130,7 @@ function Divider() {
   return <div style={{ height: 1, background: 'var(--fog-ghost)', margin: '8px 0' }} />;
 }
 
-export default function LayersPanel({ state, onChange, bottom = 16, fixed = false, forceOpen, isOwner = false, theme, onThemeChange, triggerStyle, topRight, topOffset = 80, explorerStats }: LayersPanelProps) {
+export default function LayersPanel({ state, onChange, bottom = 16, fixed = false, forceOpen, isPremium = false, theme, onThemeChange, triggerStyle, topRight, topOffset = 80, explorerStats }: LayersPanelProps) {
   const [open, setOpen] = useState(false);
   // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing forceOpen prop to open state
   useEffect(() => { if (forceOpen !== undefined) setOpen(forceOpen); }, [forceOpen]);
@@ -238,10 +238,10 @@ export default function LayersPanel({ state, onChange, bottom = 16, fixed = fals
           <Divider />
 
           {/* Personal */}
-          <Row label="My photos" on={state.showPhotos} onChange={(v) => onChange({ showPhotos: v })} hidden={!isOwner} />
-          <Row label="Personal heatmap" on={state.showPersonalHeatmap} onChange={(v) => onChange({ showPersonalHeatmap: v })} hidden={!isOwner} />
-          <Row label="Explorer tiles" on={state.showExplorer} onChange={(v) => onChange({ showExplorer: v })} hidden={!isOwner} />
-          {isOwner && state.showExplorer && explorerStats && (
+          <Row label="My photos" on={state.showPhotos} onChange={(v) => onChange({ showPhotos: v })} hidden={!isPremium} />
+          <Row label="Personal heatmap" on={state.showPersonalHeatmap} onChange={(v) => onChange({ showPersonalHeatmap: v })} hidden={!isPremium} />
+          <Row label="Explorer tiles" on={state.showExplorer} onChange={(v) => onChange({ showExplorer: v })} hidden={!isPremium} />
+          {isPremium && state.showExplorer && explorerStats && (
             <div style={{ paddingLeft: 0, paddingBottom: 2, display: 'flex', gap: 10 }}>
               <span style={{ font: '400 9px/1 var(--mono)', color: 'rgba(108,140,35,0.95)', letterSpacing: '0.03em' }}>
                 yard {explorerStats.yardSize.toLocaleString()}
@@ -252,13 +252,13 @@ export default function LayersPanel({ state, onChange, bottom = 16, fixed = fals
             </div>
           )}
 
-          {!isOwner && <Divider />}
-          {isOwner && <Divider />}
+          {!isPremium && <Divider />}
+          {isPremium && <Divider />}
 
-          {/* POIs — owner only */}
-          <Row label="Points of interest" on={state.showPOIs} onChange={(v) => onChange({ showPOIs: v })} hidden={!isOwner} />
+          {/* POIs — premium only */}
+          <Row label="Points of interest" on={state.showPOIs} onChange={(v) => onChange({ showPOIs: v })} hidden={!isPremium} />
 
-          {isOwner && <Divider />}
+          {isPremium && <Divider />}
 
           {/* Global heatmap — always shown */}
           <Row label="Global heatmap" on={state.showGlobalHeatmap} onChange={(v) => onChange({ showGlobalHeatmap: v })} />

--- a/app/components/shell/MapShell.tsx
+++ b/app/components/shell/MapShell.tsx
@@ -81,13 +81,13 @@ interface MapShellProps {
   activities: ActivitySummary[];
   avatarInitials: string;
   isLoggedIn?: boolean;
-  isOwner?: boolean;
+  isPremium?: boolean;
   initialMode?: PanelMode;
   initialSelectedId?: string | null;
   authError?: boolean;
 }
 
-export default function MapShell({ activities, avatarInitials, isLoggedIn = false, isOwner = false, initialMode = 'browse', initialSelectedId = null, authError = false }: MapShellProps) {
+export default function MapShell({ activities, avatarInitials, isLoggedIn = false, isPremium = false, initialMode = 'browse', initialSelectedId = null, authError = false }: MapShellProps) {
   const [mode, setMode] = useState<PanelMode>(initialSelectedId ? 'detail' : initialMode);
   const [selectedId, setSelectedId] = useState<string | null>(initialSelectedId);
   const [detailSnap, setDetailSnap] = useState<'mid' | 'expanded'>('mid');
@@ -198,7 +198,7 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
 
   // Trigger photo catch-up import the first time "My photos" is enabled
   useEffect(() => {
-    if (!isOwner || !layerState.showPhotos || photosImportTriggeredRef.current) return;
+    if (!isPremium || !layerState.showPhotos || photosImportTriggeredRef.current) return;
     try {
       if (localStorage.getItem('plotv2-photos-import-triggered')) {
         photosImportTriggeredRef.current = true;
@@ -213,7 +213,7 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
         }
       })
       .catch(() => { /* silently ignore */ });
-  }, [isOwner, layerState.showPhotos]);
+  }, [isPremium, layerState.showPhotos]);
 
   // Reflect panel mode in URL bar (no navigation, just history state)
   useEffect(() => {
@@ -575,10 +575,10 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
           heatmapColor={layerState.heatmapColor}
           showExplorer={layerState.showExplorer}
           onExplorerStats={setExplorerStats}
-          showOwnerPhotos={isOwner && layerState.showPhotos}
+          showOwnerPhotos={isPremium && layerState.showPhotos}
           onPhotoClick={handleOwnerPhotoClick}
           onClusterPhotosClick={handleOwnerClusterPhotosClick}
-          onHeatmapClick={isOwner ? handleHeatmapClick : undefined}
+          onHeatmapClick={isPremium ? handleHeatmapClick : undefined}
           hoveredActivityRoute={hoveredActivityRoute}
           hoveredActivityColor={hoveredActivityColor}
           onGeolocate={handleGeolocate}
@@ -589,7 +589,7 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
 
         {/* Desktop chrome — layers, compass, scale, legend (hidden on mobile) */}
         <div className="hidden sm:block">
-          <LayersPanel state={layerState} onChange={patchLayers} bottom={16} isOwner={isOwner} theme={theme} onThemeChange={handleThemeChange} explorerStats={explorerStats} />
+          <LayersPanel state={layerState} onChange={patchLayers} bottom={16} isPremium={isPremium} theme={theme} onThemeChange={handleThemeChange} explorerStats={explorerStats} />
         </div>
         <div className="hidden sm:flex absolute bottom-[68px] left-3 z-[14] items-center gap-2">
           <Compass bearing={compassBearing} onResetNorth={handleResetNorth} />
@@ -647,7 +647,7 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
       {/* Conditional non-animated elements */}
       {mode !== 'planner' && (
         <>
-          <LayersPanel state={layerState} onChange={patchLayers} fixed topRight topOffset={80} isOwner={isOwner} theme={theme} onThemeChange={handleThemeChange} explorerStats={explorerStats} triggerStyle={{ borderRadius: '50%', background: 'var(--glass-hvy)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)' }} />
+          <LayersPanel state={layerState} onChange={patchLayers} fixed topRight topOffset={80} isPremium={isPremium} theme={theme} onThemeChange={handleThemeChange} explorerStats={explorerStats} triggerStyle={{ borderRadius: '50%', background: 'var(--glass-hvy)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)' }} />
           <button
             onClick={handleOpenPlanner}
             style={{
@@ -677,7 +677,7 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
       )}
 
       {mode === 'planner' && (
-        <LayersPanel state={layerState} onChange={patchLayers} fixed topRight topOffset={126} forceOpen={mobilePlannerLayersOpen} isOwner={isOwner} theme={theme} onThemeChange={handleThemeChange} explorerStats={explorerStats} triggerStyle={{ borderRadius: '50%', background: 'var(--glass-hvy)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)' }} />
+        <LayersPanel state={layerState} onChange={patchLayers} fixed topRight topOffset={126} forceOpen={mobilePlannerLayersOpen} isPremium={isPremium} theme={theme} onThemeChange={handleThemeChange} explorerStats={explorerStats} triggerStyle={{ borderRadius: '50%', background: 'var(--glass-hvy)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)' }} />
       )}
 
       {/* Activities bottom sheet — always mounted, crossfades out when entering planner */}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -10,6 +10,12 @@ export interface SessionData {
     firstname: string;
     lastname: string;
   };
+  // Premium (backend-powered) feature access — resolved once at login by
+  // calling the backend's athlete allowlist, then cached here so per-request
+  // checks (e.g. tile requests) don't need to hit the backend. See lib/entitlements.ts.
+  entitlements?: {
+    premium: boolean;
+  };
   oauthState?: string;
 }
 

--- a/lib/backend.ts
+++ b/lib/backend.ts
@@ -1,4 +1,28 @@
 import type { ActivityData } from '@/lib/types';
+import type { SessionData } from '@/lib/auth';
+import { hasPremium } from '@/lib/entitlements';
+
+export interface PremiumBackendConfig {
+  url: string;
+  token: string;
+  athleteId: string;
+}
+
+/**
+ * Resolves backend config for a premium-gated route (personal heatmap tiles,
+ * explorer tiles, photos), or null if the athlete isn't entitled or the
+ * backend isn't configured. Callers should respond 404 on null — intentionally
+ * hiding the feature's existence from non-premium athletes, matching the
+ * existing routes' behavior.
+ */
+export function getPremiumBackendConfig(session: Pick<SessionData, 'athlete' | 'entitlements'>): PremiumBackendConfig | null {
+  const url = process.env.TILES_BACKEND_URL;
+  const token = process.env.TILES_BEARER_TOKEN;
+  if (!url || !token || !session.athlete || !hasPremium(session)) {
+    return null;
+  }
+  return { url, token, athleteId: String(session.athlete.id) };
+}
 
 interface RecentActivityResponse {
   id: number;
@@ -20,6 +44,51 @@ function getBackendConfig() {
     throw new Error('Missing TILES_BACKEND_URL, TILES_BEARER_TOKEN, or TILES_ATHLETE_ID');
   }
   return { url, token, athleteId };
+}
+
+export interface StravaTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+  athlete: { id: number; firstname: string; lastname: string };
+}
+
+/**
+ * Onboards an athlete into the backend (upsert + import-if-empty) and returns
+ * whether they're on the premium feature allowlist. Called once at login
+ * (see app/api/auth/callback/route.ts); the result is cached in the session
+ * so later requests don't need to call the backend again. Best-effort — if
+ * the backend is unreachable, the athlete is treated as non-premium and the
+ * base app is unaffected.
+ */
+export async function bootstrapPremiumAccess(data: StravaTokenResponse): Promise<boolean> {
+  const url = process.env.TILES_BACKEND_URL;
+  const token = process.env.TILES_BEARER_TOKEN;
+  if (!url || !token) return false;
+
+  try {
+    const res = await fetch(`${url}/users/bootstrap`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        athlete_id: data.athlete.id,
+        first_name: data.athlete.firstname,
+        last_name: data.athlete.lastname,
+        access_token: data.access_token,
+        refresh_token: data.refresh_token,
+        expires_at: data.expires_at,
+      }),
+    });
+    if (!res.ok) return false;
+
+    const body: { allowed: boolean } = await res.json();
+    return !!body.allowed;
+  } catch {
+    return false;
+  }
 }
 
 export async function getRecentActivityFromBackend(minDistanceMeters: number): Promise<ActivityData> {

--- a/lib/entitlements.ts
+++ b/lib/entitlements.ts
@@ -1,0 +1,13 @@
+import type { SessionData } from '@/lib/auth';
+
+/**
+ * Whether the logged-in athlete has access to premium (backend-powered)
+ * features: personal heatmap tiles, explorer tiles, and photo import/serving.
+ *
+ * Backed by the athlete allowlist in plot-backend; the decision is resolved
+ * once at login (see app/api/auth/callback/route.ts) and cached in the
+ * session, so this check is zero-I/O.
+ */
+export function hasPremium(session: Pick<SessionData, 'entitlements'>): boolean {
+  return !!session.entitlements?.premium;
+}


### PR DESCRIPTION
## Summary
- Replaces the single-owner `TILES_ATHLETE_ID` env var gate (compared inline across 6 API routes, mirrored by an `isOwner` boolean) with `hasPremium(session)`, backed by a new athlete allowlist in plot-backend's D1 (companion change, already deployed).
- The premium-access decision is resolved once at login — the OAuth callback calls the backend's new `POST /users/bootstrap`, which onboards the athlete (upsert + import-if-empty) if they're allowlisted, and returns `{ allowed }` to cache in the session. Per-request checks (including tile requests) stay zero-I/O.
- `isOwner` is renamed to `isPremium` throughout `page.tsx` → `MapShell` → `LayersPanel`, since it no longer means "the app owner" — any allowlisted athlete gets their own personal heatmap tiles, explorer tiles, and photos.

## Why
Plot is about to gate more features to a handful of specific Strava athletes (not just the owner). The old mechanism was a single hardcoded athlete ID duplicated across the frontend env and implicit backend state, with no way to add someone without a redeploy. This moves the source of truth to D1 (a single `wrangler d1 execute` insert to add an athlete, no redeploy) while keeping the base multi-tenant experience (activities, maps, planner) — which already worked per-athlete via iron-session + direct Strava calls — completely untouched.

## Notable decisions
- Consolidated the 6 duplicated route guards into `lib/backend.ts`'s `getPremiumBackendConfig()`. While doing so, fixed a latent bug: the two `photos` routes were forwarding the env owner ID as `X-Athlete-Id` instead of the logged-in athlete's own ID.
- Bootstrap is best-effort — if the backend is unreachable at login, the athlete is treated as non-premium and the base app is unaffected.
- The wallpaper feature (`lib/backend.ts`'s `getRecentActivityFromBackend`) intentionally stays owner-only for now — it's the last remaining use of `TILES_ATHLETE_ID`.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` — no new issues (pre-existing warnings only, in untouched files)
- [ ] Preview deploy: log in as owner → premium toggles + tiles/explorer/photos still load
- [ ] Preview deploy: log in as a non-allowlisted athlete → base app works, premium toggles hidden, premium routes 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyiDY8iudoMUMtHxKKnrBJ