### PR TITLE
feat(planner): add premium saved-routes library

### DIFF
--- a/app/(main)/planner/useRouteHistory.ts
+++ b/app/(main)/planner/useRouteHistory.ts
@@ -1,226 +1,112 @@
 'use client';
 
-import { useReducer } from 'react';
-import { Waypoint, RouteSegment } from '@/lib/types';
+import { useCallback, useReducer } from 'react';
+import {
+  type RouteState,
+  type RouteContentAction,
+  applyAction,
+  replayAll,
+  EMPTY_ROUTE_STATE,
+} from '@/lib/route-actions';
 
-export interface RouteState {
-  waypoints: Waypoint[];
-  segments: RouteSegment[];
-}
+export type { RouteState, RouteContentAction } from '@/lib/route-actions';
 
 export type RouteAction =
-  | { type: 'ADD_WAYPOINT'; waypoint: Waypoint; snap?: boolean }
-  | { type: 'INSERT_WAYPOINT'; index: number; waypoint: Waypoint; snap?: boolean }
-  | { type: 'MOVE_WAYPOINT'; index: number; waypoint: Waypoint }
-  | { type: 'REMOVE_WAYPOINT'; index: number }
-  | { type: 'CLEAR' }
+  | RouteContentAction
   | { type: 'UNDO' }
-  | { type: 'REDO' }
-  | { type: 'LOAD'; waypoints: Waypoint[]; segments?: RouteSegment[] }
-  | { type: 'UPDATE_SEGMENT'; index: number; coordinates: Waypoint[]; distance?: number }
-  | { type: 'TOGGLE_SEGMENT_SNAP'; index: number }
-  | { type: 'REVERSE' };
+  | { type: 'REDO' };
+
+type InternalAction =
+  | RouteAction
+  | { type: 'RESTORE'; actions: RouteContentAction[]; cursor: number };
 
 interface HistoryState {
-  past: RouteState[];
-  present: RouteState;
-  future: RouteState[];
+  actions: RouteContentAction[];
+  cursor: number; // present = presentByCursor[cursor]
+  // presentByCursor[i] = route state after actions[0, i) — computed incrementally as
+  // actions are appended (or fully, once, on RESTORE/LOAD) so undo/redo is an O(1)
+  // array lookup instead of a replay. Never persisted — rebuilt from `actions` on hydration.
+  presentByCursor: RouteState[];
 }
 
-function applyAction(state: RouteState, action: RouteAction): RouteState | null {
-  switch (action.type) {
-    case 'ADD_WAYPOINT': {
-      const newSegments = [...state.segments];
-      if (state.waypoints.length > 0) {
-        newSegments.push({
-          snapped: action.snap ?? false,
-          coordinates: [],
-        });
-      }
-      return {
-        waypoints: [...state.waypoints, action.waypoint],
-        segments: newSegments,
-      };
-    }
-    case 'INSERT_WAYPOINT': {
-      const { index, waypoint } = action;
-      const newWaypoints = [
-        ...state.waypoints.slice(0, index),
-        waypoint,
-        ...state.waypoints.slice(index),
-      ];
-
-      const newSegments = [...state.segments];
-      if (state.waypoints.length < 2) {
-        // Was 0 or 1 waypoint, inserting makes it 2 — add a segment
-        if (newWaypoints.length >= 2) {
-          newSegments.push({
-            snapped: action.snap ?? false,
-            coordinates: [],
-          });
-        }
-      } else {
-        // Split the segment at (index - 1) into two
-        const segIdx = Math.max(0, index - 1);
-        const original = newSegments[segIdx];
-        const inheritSnap = action.snap ?? original?.snapped ?? false;
-        newSegments.splice(segIdx, 1,
-          { snapped: inheritSnap, coordinates: [] },
-          { snapped: inheritSnap, coordinates: [] },
-        );
-      }
-
-      return { waypoints: newWaypoints, segments: newSegments };
-    }
-    case 'MOVE_WAYPOINT': {
-      const newWaypoints = state.waypoints.map((wp, i) =>
-        i === action.index ? action.waypoint : wp
-      );
-      const newSegments = state.segments.map((seg, i) => {
-        // Clear coordinates of adjacent segments (before and after moved waypoint)
-        if (i === action.index - 1 || i === action.index) {
-          return { ...seg, coordinates: [], distance: undefined };
-        }
-        return seg;
-      });
-      return { waypoints: newWaypoints, segments: newSegments };
-    }
-    case 'REMOVE_WAYPOINT': {
-      const { index } = action;
-      const newWaypoints = state.waypoints.filter((_, i) => i !== index);
-      const newSegments = [...state.segments];
-
-      if (state.waypoints.length <= 2) {
-        // Removing takes us to 0 or 1 waypoint — no segments
-        return { waypoints: newWaypoints, segments: [] };
-      }
-
-      if (index === 0) {
-        // Remove first segment
-        newSegments.splice(0, 1);
-      } else if (index === state.waypoints.length - 1) {
-        // Remove last segment
-        newSegments.splice(newSegments.length - 1, 1);
-      } else {
-        // Merge segments[index-1] and segments[index] into one
-        const before = newSegments[index - 1];
-        const after = newSegments[index];
-        const merged: RouteSegment = {
-          snapped: before.snapped || after.snapped,
-          coordinates: [],
-        };
-        newSegments.splice(index - 1, 2, merged);
-      }
-
-      return { waypoints: newWaypoints, segments: newSegments };
-    }
-    case 'CLEAR':
-      if (state.waypoints.length === 0) return null;
-      return { waypoints: [], segments: [] };
-    case 'UPDATE_SEGMENT': {
-      if (action.index < 0 || action.index >= state.segments.length) return null;
-      const newSegments = state.segments.map((seg, i) => {
-        if (i === action.index) {
-          return {
-            ...seg,
-            coordinates: action.coordinates,
-            distance: action.distance,
-          };
-        }
-        return seg;
-      });
-      return { waypoints: state.waypoints, segments: newSegments };
-    }
-    case 'TOGGLE_SEGMENT_SNAP': {
-      if (action.index < 0 || action.index >= state.segments.length) return null;
-      const newSegments = state.segments.map((seg, i) => {
-        if (i === action.index) {
-          return {
-            snapped: !seg.snapped,
-            coordinates: [],
-            distance: undefined,
-          };
-        }
-        return seg;
-      });
-      return { waypoints: state.waypoints, segments: newSegments };
-    }
-    case 'REVERSE': {
-      if (state.waypoints.length < 2) return null;
-      const waypoints = [...state.waypoints].reverse();
-      const segments = [...state.segments].reverse().map(seg => ({
-        ...seg,
-        coordinates: [...seg.coordinates].reverse(),
-      }));
-      return { waypoints, segments };
-    }
-    default:
-      return null;
-  }
+export interface RouteHistoryInit {
+  actions: RouteContentAction[];
+  cursor: number;
 }
 
-function historyReducer(state: HistoryState, action: RouteAction): HistoryState {
+function initHistoryState(init?: RouteHistoryInit): HistoryState {
+  const actions = init?.actions ?? [];
+  const cursor = init?.cursor ?? 0;
+  return { actions, cursor, presentByCursor: replayAll(actions) };
+}
+
+function historyReducer(state: HistoryState, action: InternalAction): HistoryState {
   switch (action.type) {
+    case 'RESTORE':
+      return { actions: action.actions, cursor: action.cursor, presentByCursor: replayAll(action.actions) };
     case 'UNDO': {
-      if (state.past.length === 0) return state;
-      const previous = state.past[state.past.length - 1];
-      return {
-        past: state.past.slice(0, -1),
-        present: previous,
-        future: [state.present, ...state.future],
-      };
+      if (state.cursor === 0) return state;
+      let cursor = state.cursor - 1;
+      // An UPDATE_SEGMENT is an async side-effect of the action right before it (routing
+      // fetch resolving) — skip back over any trailing run of them so one Undo press
+      // removes the whole user gesture, not just its routed-coordinate patch.
+      while (cursor > 0 && state.actions[cursor].type === 'UPDATE_SEGMENT') cursor -= 1;
+      return { ...state, cursor };
     }
     case 'REDO': {
-      if (state.future.length === 0) return state;
-      const next = state.future[0];
-      return {
-        past: [...state.past, state.present],
-        present: next,
-        future: state.future.slice(1),
-      };
+      if (state.cursor >= state.actions.length) return state;
+      let cursor = state.cursor + 1;
+      while (cursor < state.actions.length && state.actions[cursor].type === 'UPDATE_SEGMENT') cursor += 1;
+      return { ...state, cursor };
     }
-    case 'LOAD': {
-      return {
-        past: [],
-        present: {
-          waypoints: action.waypoints,
-          segments: action.segments ?? [],
-        },
-        future: [],
-      };
-    }
-    case 'UPDATE_SEGMENT': {
-      // UPDATE_SEGMENT should NOT create undo history — it's an async side-effect
-      const newPresent = applyAction(state.present, action);
-      if (!newPresent) return state;
-      return { ...state, present: newPresent };
-    }
+    case 'LOAD':
+      // GPX import / "Open in Planner" / legacy-format migration — resets history to a
+      // single seed action rather than appending, matching today's replace-in-place UX.
+      return { actions: [action], cursor: 1, presentByCursor: replayAll([action]) };
     default: {
-      const newPresent = applyAction(state.present, action);
-      if (!newPresent) return state;
-      return {
-        past: [...state.past, state.present],
-        present: newPresent,
-        future: [],
-      };
+      // Any other content action (including UPDATE_SEGMENT): discard redo tail if the
+      // user was mid-undo, append, and advance the cursor to the new tip.
+      const actions = state.cursor < state.actions.length
+        ? [...state.actions.slice(0, state.cursor), action]
+        : [...state.actions, action];
+      const basePresent = state.presentByCursor[state.cursor] ?? EMPTY_ROUTE_STATE;
+      const nextPresent = applyAction(basePresent, action) ?? basePresent;
+      const presentByCursor = [...state.presentByCursor.slice(0, state.cursor + 1), nextPresent];
+      return { actions, cursor: actions.length, presentByCursor };
     }
   }
 }
 
-const initialState: HistoryState = {
-  past: [],
-  present: { waypoints: [], segments: [] },
-  future: [],
-};
+export function useRouteHistory(init?: RouteHistoryInit) {
+  const [state, rawDispatch] = useReducer(historyReducer, init, initHistoryState);
 
-export function useRouteHistory() {
-  const [state, dispatch] = useReducer(historyReducer, initialState);
+  const present = state.presentByCursor[state.cursor] ?? EMPTY_ROUTE_STATE;
+
+  const dispatch = useCallback((action: RouteAction) => {
+    if (action.type === 'UNDO' || action.type === 'REDO' || action.type === 'LOAD') {
+      rawDispatch(action);
+      return;
+    }
+    // No-op guard, mirroring the old applyAction null-return convention — skip recording
+    // history entries that wouldn't change anything (e.g. CLEAR on an empty route).
+    if (!applyAction(present, action)) return;
+    rawDispatch(action);
+  }, [present]);
+
+  // Used to hydrate a route asynchronously (premium: after GET /api/routes/:id resolves).
+  // Synchronous hydration (localStorage) can instead pass `init` directly.
+  const restore = useCallback((history: RouteHistoryInit) => {
+    rawDispatch({ type: 'RESTORE', actions: history.actions, cursor: history.cursor });
+  }, []);
 
   return {
-    waypoints: state.present.waypoints,
-    segments: state.present.segments,
-    canUndo: state.past.length > 0,
-    canRedo: state.future.length > 0,
+    waypoints: present.waypoints,
+    segments: present.segments,
+    canUndo: state.cursor > 0,
+    canRedo: state.cursor < state.actions.length,
     dispatch,
+    restore,
+    actions: state.actions,
+    cursor: state.cursor,
   };
 }

--- a/app/api/geocode/reverse/route.ts
+++ b/app/api/geocode/reverse/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth';
+import { hasPremium } from '@/lib/entitlements';
+
+interface PhotonFeature {
+  properties: {
+    name?: string;
+    county?: string;
+    state?: string;
+    country?: string;
+  };
+}
+
+// Reverse-geocodes a saved route's start point into a short "place · region" label.
+// Premium-only — location labels are a saved-routes-library concept; free users never
+// see or need one.
+export async function GET(request: NextRequest) {
+  const session = await getSession();
+  if (!session.athlete || !hasPremium(session)) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  const lat = request.nextUrl.searchParams.get('lat');
+  const lng = request.nextUrl.searchParams.get('lng');
+  if (!lat || !lng) {
+    return NextResponse.json({ location: null });
+  }
+
+  try {
+    const url = new URL('https://photon.komoot.io/reverse');
+    url.searchParams.set('lat', lat);
+    url.searchParams.set('lon', lng);
+    url.searchParams.set('lang', 'en');
+
+    const res = await fetch(url.toString());
+    if (!res.ok) {
+      return NextResponse.json({ location: null }, { status: 502 });
+    }
+
+    const data = await res.json();
+    const feature: PhotonFeature | undefined = data.features?.[0];
+    if (!feature) {
+      return NextResponse.json({ location: null });
+    }
+
+    const place = feature.properties.name;
+    const region = feature.properties.county || feature.properties.state || feature.properties.country;
+    const location = [place, region].filter(Boolean).join(' · ') || null;
+
+    return NextResponse.json({ location });
+  } catch {
+    return NextResponse.json({ location: null }, { status: 502 });
+  }
+}

--- a/app/api/routes/[id]/duplicate/route.ts
+++ b/app/api/routes/[id]/duplicate/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth';
+import { getPremiumBackendConfig } from '@/lib/backend';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const session = await getSession();
+  const backend = getPremiumBackendConfig(session);
+
+  if (!backend) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  try {
+    const res = await fetch(`${backend.url}/routes/${id}/duplicate`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${backend.token}`,
+        'X-Athlete-Id': backend.athleteId,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      return new NextResponse(null, { status: res.status });
+    }
+
+    return NextResponse.json(await res.json());
+  } catch {
+    return new NextResponse(null, { status: 502 });
+  }
+}

--- a/app/api/routes/[id]/route.ts
+++ b/app/api/routes/[id]/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth';
+import { getPremiumBackendConfig } from '@/lib/backend';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const session = await getSession();
+  const backend = getPremiumBackendConfig(session);
+
+  if (!backend) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  try {
+    const res = await fetch(`${backend.url}/routes/${id}`, {
+      headers: {
+        Authorization: `Bearer ${backend.token}`,
+        'X-Athlete-Id': backend.athleteId,
+      },
+    });
+
+    if (!res.ok) {
+      return new NextResponse(null, { status: res.status });
+    }
+
+    return NextResponse.json(await res.json());
+  } catch {
+    return new NextResponse(null, { status: 502 });
+  }
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const session = await getSession();
+  const backend = getPremiumBackendConfig(session);
+
+  if (!backend) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  try {
+    const res = await fetch(`${backend.url}/routes/${id}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${backend.token}`,
+        'X-Athlete-Id': backend.athleteId,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      return new NextResponse(null, { status: res.status });
+    }
+
+    return NextResponse.json(await res.json());
+  } catch {
+    return new NextResponse(null, { status: 502 });
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const session = await getSession();
+  const backend = getPremiumBackendConfig(session);
+
+  if (!backend) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  try {
+    const res = await fetch(`${backend.url}/routes/${id}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${backend.token}`,
+        'X-Athlete-Id': backend.athleteId,
+      },
+    });
+
+    if (!res.ok) {
+      return new NextResponse(null, { status: res.status });
+    }
+
+    return NextResponse.json(await res.json());
+  } catch {
+    return new NextResponse(null, { status: 502 });
+  }
+}

--- a/app/api/routes/route.ts
+++ b/app/api/routes/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth';
+import { getPremiumBackendConfig } from '@/lib/backend';
+
+export async function GET() {
+  const session = await getSession();
+  const backend = getPremiumBackendConfig(session);
+
+  if (!backend) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  try {
+    const res = await fetch(`${backend.url}/routes`, {
+      headers: {
+        Authorization: `Bearer ${backend.token}`,
+        'X-Athlete-Id': backend.athleteId,
+      },
+    });
+
+    if (!res.ok) {
+      return new NextResponse(null, { status: res.status });
+    }
+
+    return NextResponse.json(await res.json());
+  } catch {
+    return new NextResponse(null, { status: 502 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  const backend = getPremiumBackendConfig(session);
+
+  if (!backend) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  try {
+    const res = await fetch(`${backend.url}/routes`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${backend.token}`,
+        'X-Athlete-Id': backend.athleteId,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      return new NextResponse(null, { status: res.status });
+    }
+
+    return NextResponse.json(await res.json());
+  } catch {
+    return new NextResponse(null, { status: 502 });
+  }
+}

--- a/app/components/shell/DeleteRouteConfirm.tsx
+++ b/app/components/shell/DeleteRouteConfirm.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+interface DeleteRouteConfirmProps {
+  name: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+  style?: React.CSSProperties;
+}
+
+export default function DeleteRouteConfirm({ name, onCancel, onConfirm, style }: DeleteRouteConfirmProps) {
+  return (
+    <div
+      onClick={(e) => e.stopPropagation()}
+      style={{
+        width: 208,
+        background: 'var(--glass-hvy)',
+        backdropFilter: 'blur(12px)',
+        WebkitBackdropFilter: 'blur(12px)',
+        border: '1px solid rgba(200,60,60,0.35)',
+        borderRadius: 5,
+        padding: 12,
+        boxShadow: '0 8px 24px rgba(0,0,0,0.55)',
+        ...style,
+      }}
+    >
+      <div style={{ font: '500 10px/1.5 var(--mono)', color: 'var(--fog)', marginBottom: 10 }}>
+        Delete <strong style={{ color: 'var(--ice)', fontWeight: 600 }}>&ldquo;{name}&rdquo;</strong>? This can&apos;t be undone.
+      </div>
+      <div style={{ display: 'flex', gap: 6 }}>
+        <button
+          onClick={onCancel}
+          style={{
+            flex: 1, height: 26, borderRadius: 3, font: '600 8.5px/1 var(--mono)', letterSpacing: '.06em',
+            textTransform: 'uppercase', cursor: 'pointer', background: 'transparent', border: '1px solid var(--p3)', color: 'var(--fog-dim)',
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onConfirm}
+          style={{
+            flex: 1, height: 26, borderRadius: 3, font: '600 8.5px/1 var(--mono)', letterSpacing: '.06em',
+            textTransform: 'uppercase', cursor: 'pointer', background: 'rgba(200,60,60,0.85)', border: 'none', color: 'var(--ice)',
+          }}
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/shell/MapShell.tsx
+++ b/app/components/shell/MapShell.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import { createPortal } from 'react-dom';
-import { X, Image as ImageIcon, Download, Upload } from 'lucide-react';
+import { X, Image as ImageIcon, Download, Upload, ChevronRight, MapPin } from 'lucide-react';
 import ImportRoutePopover from '@/app/components/shell/ImportRoutePopover';
 import dynamic from 'next/dynamic';
 import Map from 'ol/Map';
@@ -16,12 +16,20 @@ import { useRouteSnapping } from '@/app/(main)/planner/useRouteSnapping';
 import { useElevationProfile } from '@/app/(main)/planner/useElevationProfile';
 import { calculateDistance } from '@/app/(main)/planner/route-utils';
 import { saveRoute, loadRoute } from '@/lib/route-storage';
+import { getActiveRouteId, setActiveRouteId } from '@/lib/active-route';
+import { replayToCursor } from '@/lib/route-actions';
+import {
+  listRoutes, createRoute, getRoute, updateRoute, duplicateRoute, deleteRoute,
+  displayRouteLabel, UNTITLED_ROUTE_NAME, type RouteSummary,
+} from '@/lib/saved-routes';
 import { selectGpxWaypoints, downloadGpx, parseGpx } from '@/lib/gpx';
 import { OS_PROJECTION } from '@/lib/map-config';
 import LeftPanel from './LeftPanel';
 import BrowsePanel from './BrowsePanel';
 import DetailPanel from './DetailPanel';
 import PlannerPanel from './PlannerPanel';
+import SavedRoutesPicker from './SavedRoutesPicker';
+import MobileRoutesSheet from './MobileRoutesSheet';
 import UnauthPanel from './UnauthPanel';
 import MobileHeader from './MobileHeader';
 import MobileBottomSheet from './MobileBottomSheet';
@@ -121,7 +129,7 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
   const handleElevationHover = useCallback((pt: ElevationHoverPoint | null) => setElevationHoverPoint(pt), []);
 
   // Planner state
-  const { waypoints, segments, canUndo, canRedo, dispatch } = useRouteHistory();
+  const { waypoints, segments, canUndo, canRedo, dispatch, restore, actions, cursor } = useRouteHistory();
   const [addPointsEnabled, setAddPointsEnabled] = useState(true);
   const [snapEnabled, setSnapEnabled] = useState(true);
   const [isExportingImage, setIsExportingImage] = useState(false);
@@ -129,13 +137,269 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const waypointsRef = useRef(waypoints);
   const segmentsRef = useRef(segments);
+  const actionsRef = useRef(actions);
+  const cursorRef = useRef(cursor);
   waypointsRef.current = waypoints;
   segmentsRef.current = segments;
+  actionsRef.current = actions;
+  cursorRef.current = cursor;
 
   useRouteSnapping({ waypoints, segments, dispatch });
   const { elevationData, isLoading: isLoadingElevation } = useElevationProfile(waypoints, segments);
 
   const distance = useMemo(() => calculateDistance(waypoints, segments), [waypoints, segments]);
+  const distanceRef = useRef(distance);
+  distanceRef.current = distance;
+
+  // ── Saved routes (premium) ─────────────────────────────────────────────
+  const [routesList, setRoutesList] = useState<RouteSummary[]>([]);
+  const [routeMeta, setRouteMeta] = useState<{ id: string | null; name: string; location: string | null }>({ id: null, name: 'Untitled route', location: null });
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved'>('idle');
+  const [isLocating, setIsLocating] = useState(false);
+  const [routeHydrated, setRouteHydrated] = useState(false);
+  const [mobileRoutesSheetOpen, setMobileRoutesSheetOpen] = useState(false);
+  const [premiumInitialView, setPremiumInitialView] = useState<{ center: [number, number]; zoom: number } | null>(null);
+  const routeMetaRef = useRef(routeMeta);
+  routeMetaRef.current = routeMeta;
+
+  // Overlay the active route's live in-memory state (name, location, stats) onto its row
+  // in the list — renames and stat changes must show up immediately, not just after the
+  // next backend refetch (autosave is debounced, so waiting for it would lag visibly).
+  const displayRoutesList = useMemo(() => {
+    if (!routeMeta.id) return routesList;
+    return routesList.map((r) => r.id === routeMeta.id
+      ? { ...r, name: routeMeta.name, location: routeMeta.location, distanceM: distance, waypointCount: waypoints.length }
+      : r);
+  }, [routesList, routeMeta.id, routeMeta.name, routeMeta.location, distance, waypoints.length]);
+
+  const hydratedRef = useRef(false);
+  const createInFlightRef = useRef(false);
+  const suppressNextAutosaveRef = useRef(false);
+  const premiumSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const refreshRoutesList = useCallback(() => {
+    if (!isPremium) return;
+    listRoutes().then(setRoutesList);
+  }, [isPremium]);
+
+  useEffect(() => { refreshRoutesList(); }, [refreshRoutesList]);
+
+  // Debounced PUT — shared by the content-change effect and the moveend map handler below,
+  // matching the existing dual-trigger local autosave pattern.
+  const schedulePremiumSave = useCallback(() => {
+    if (!isPremium || !routeMetaRef.current.id) return;
+    if (suppressNextAutosaveRef.current) {
+      suppressNextAutosaveRef.current = false;
+      return;
+    }
+    setSaveStatus('saving');
+    if (premiumSaveTimerRef.current) clearTimeout(premiumSaveTimerRef.current);
+    premiumSaveTimerRef.current = setTimeout(() => {
+      const id = routeMetaRef.current.id;
+      if (!id) return;
+      const map = mapInstanceRef.current;
+      const center = (map?.getView().getCenter() as [number, number]) ?? [0, 0];
+      const zoom = map?.getView().getZoom() ?? 7;
+      updateRoute(id, {
+        name: routeMetaRef.current.name,
+        location: routeMetaRef.current.location,
+        distanceM: distanceRef.current,
+        waypointCount: waypointsRef.current.length,
+        actions: actionsRef.current,
+        cursor: cursorRef.current,
+        mapCenter: center,
+        mapZoom: zoom,
+      }).then((summary) => {
+        if (summary) setSaveStatus('saved');
+      });
+    }, 1800);
+  }, [isPremium]);
+
+  // Hydrate the active route on mount — premium fetches from the backend, free reads
+  // localStorage (unchanged mechanism, just the new action-log shape). routeHydrated
+  // gates the route-identity UI so it doesn't flash "Untitled route" before the real
+  // name (if any) has loaded.
+  useEffect(() => {
+    if (isPremium) {
+      const id = getActiveRouteId();
+      if (!id) {
+        hydratedRef.current = true;
+        setRouteHydrated(true);
+        return;
+      }
+      getRoute(id).then((detail) => {
+        if (!detail) {
+          // Stale pointer — the route was deleted elsewhere (e.g. another device)
+          setActiveRouteId(null);
+          hydratedRef.current = true;
+          setRouteHydrated(true);
+          return;
+        }
+        suppressNextAutosaveRef.current = true;
+        restore({ actions: detail.actions, cursor: detail.cursor });
+        setRouteMeta({ id: detail.id, name: detail.name, location: detail.location });
+        setPremiumInitialView({ center: detail.mapCenter, zoom: detail.mapZoom });
+        hydratedRef.current = true;
+        setRouteHydrated(true);
+      });
+    } else {
+      const stored = loadRoute();
+      if (stored?.actions?.length) {
+        restore({ actions: stored.actions, cursor: stored.cursor });
+      }
+      hydratedRef.current = true;
+      setRouteHydrated(true);
+    }
+    // Runs once on mount — isPremium is a stable prop for the lifetime of a session.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Apply the premium route's saved map view once the map is ready (fetch and map-ready
+  // can resolve in either order).
+  useEffect(() => {
+    if (!mapReady || !premiumInitialView) return;
+    const map = mapInstanceRef.current;
+    if (!map) return;
+    if (isValidBNG(premiumInitialView.center)) {
+      map.getView().setCenter(premiumInitialView.center);
+      map.getView().setZoom(premiumInitialView.zoom);
+    }
+    setPremiumInitialView(null);
+  }, [mapReady, premiumInitialView]);
+
+  // Create the backend route record silently on the first waypoint of a fresh session
+  // (no active route yet) — mirrors the free-tier "autosave-first" behaviour.
+  useEffect(() => {
+    if (!isPremium || !hydratedRef.current) return;
+    if (routeMeta.id || waypoints.length === 0 || createInFlightRef.current) return;
+    createInFlightRef.current = true;
+    createRoute('Untitled route').then((summary) => {
+      createInFlightRef.current = false;
+      if (!summary) return;
+      setActiveRouteId(summary.id);
+      setRouteMeta({ id: summary.id, name: summary.name, location: summary.location });
+      refreshRoutesList();
+    });
+  }, [isPremium, routeMeta.id, waypoints.length, refreshRoutesList]);
+
+  // Reverse-geocode the start point whenever the active route has waypoints but no
+  // location yet — covers every path that can produce that state (auto-created on first
+  // waypoint, explicit "+ New route" then plotting, or a hydrated/older route that never
+  // got a location). Guarded per-route-id so it fires once, not on every waypoint edit.
+  const geocodedRouteIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!isPremium || !routeMeta.id || routeMeta.location || waypoints.length === 0) return;
+    if (geocodedRouteIdRef.current === routeMeta.id) return;
+    geocodedRouteIdRef.current = routeMeta.id;
+    const id = routeMeta.id;
+    const first = waypointsRef.current[0];
+    if (!first) return;
+    setIsLocating(true);
+    fetch(`/api/geocode/reverse?lat=${first.lat}&lng=${first.lng}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: { location?: string | null } | null) => {
+        if (data?.location) {
+          setRouteMeta((m) => (m.id === id ? { ...m, location: data.location ?? null } : m));
+        }
+      })
+      .catch(() => { /* silently ignore — location is a nice-to-have, not load-bearing */ })
+      .finally(() => setIsLocating(false));
+  }, [isPremium, routeMeta.id, routeMeta.location, waypoints.length]);
+
+  // Premium autosave — triggers on content or identity changes; moveend (below) triggers
+  // the same debounce for map-view-only changes.
+  useEffect(() => {
+    schedulePremiumSave();
+  }, [actions, cursor, routeMeta.name, routeMeta.location, schedulePremiumSave]);
+
+  const handleSelectRoute = useCallback((id: string) => {
+    if (id === routeMetaRef.current.id) return;
+    setRouteHydrated(false);
+    getRoute(id).then((detail) => {
+      if (!detail) {
+        setRouteHydrated(true);
+        return;
+      }
+      suppressNextAutosaveRef.current = true;
+      restore({ actions: detail.actions, cursor: detail.cursor });
+      setRouteMeta({ id: detail.id, name: detail.name, location: detail.location });
+      setActiveRouteId(detail.id);
+      setPremiumInitialView({ center: detail.mapCenter, zoom: detail.mapZoom });
+      setRouteHydrated(true);
+    });
+  }, [restore]);
+
+  const handleCreateNewRoute = useCallback(() => {
+    createRoute('Untitled route').then((summary) => {
+      if (!summary) return;
+      suppressNextAutosaveRef.current = true;
+      restore({ actions: [], cursor: 0 });
+      setRouteMeta({ id: summary.id, name: summary.name, location: summary.location });
+      setActiveRouteId(summary.id);
+      refreshRoutesList();
+    });
+  }, [restore, refreshRoutesList]);
+
+  const handleRenameActive = useCallback((name: string) => {
+    setRouteMeta((m) => ({ ...m, name }));
+  }, []);
+
+  const handleRenameRoute = useCallback((id: string, name: string) => {
+    if (id === routeMetaRef.current.id) {
+      setRouteMeta((m) => ({ ...m, name }));
+      return;
+    }
+    getRoute(id).then((detail) => {
+      if (!detail) return;
+      updateRoute(id, {
+        name,
+        location: detail.location,
+        distanceM: detail.distanceM,
+        waypointCount: detail.waypointCount,
+        actions: detail.actions,
+        cursor: detail.cursor,
+        mapCenter: detail.mapCenter,
+        mapZoom: detail.mapZoom,
+        mapRotation: detail.mapRotation,
+      }).then(() => refreshRoutesList());
+    });
+  }, [refreshRoutesList]);
+
+  const handleDuplicateRoute = useCallback((id: string) => {
+    (async () => {
+      let wps = waypointsRef.current;
+      let segs = segmentsRef.current;
+      let baseName = routeMetaRef.current.name;
+      if (id !== routeMetaRef.current.id) {
+        const detail = await getRoute(id);
+        if (!detail) return;
+        const replayed = replayToCursor(detail.actions, detail.cursor);
+        wps = replayed.waypoints;
+        segs = replayed.segments;
+        baseName = detail.name;
+      }
+      await duplicateRoute(id, `${baseName} (copy)`, wps, segs);
+      refreshRoutesList();
+    })();
+  }, [refreshRoutesList]);
+
+  const handleDeleteRoute = useCallback((id: string) => {
+    deleteRoute(id).then((ok) => {
+      if (!ok) return;
+      if (id === routeMetaRef.current.id) {
+        const next = routesList.find((r) => r.id !== id);
+        if (next) {
+          handleSelectRoute(next.id);
+        } else {
+          setActiveRouteId(null);
+          setRouteMeta({ id: null, name: 'Untitled route', location: null });
+          suppressNextAutosaveRef.current = true;
+          restore({ actions: [], cursor: 0 });
+        }
+      }
+      refreshRoutesList();
+    });
+  }, [routesList, handleSelectRoute, restore, refreshRoutesList]);
 
   const elevGain = useMemo(() => {
     if (!elevationData || elevationData.length < 2) return 0;
@@ -224,25 +488,19 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
     window.history.replaceState(null, '', path);
   }, [mode, selectedId]);
 
-  // Load saved route on mount
+  // Auto-save route locally — free tier only; premium autosave is the effect above.
+  // Only runs when map is ready to avoid persisting [0,0] center.
   useEffect(() => {
-    const stored = loadRoute();
-    if (stored?.waypoints.length) {
-      dispatch({ type: 'LOAD', waypoints: stored.waypoints, segments: stored.segments });
-    }
-  }, [dispatch]);
-
-  // Auto-save route — only runs when map is ready to avoid persisting [0,0] center
-  useEffect(() => {
+    if (isPremium) return;
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(() => {
       const map = mapInstanceRef.current;
       if (!map) return;
       const center = map.getView().getCenter() as [number, number];
       const zoom = map.getView().getZoom() ?? 7;
-      saveRoute(waypointsRef.current, segmentsRef.current, center, zoom);
+      saveRoute({ actions: actionsRef.current, cursor: cursorRef.current, mapCenter: center, mapZoom: zoom });
     }, 500);
-  }, [waypoints, segments]);
+  }, [actions, cursor, isPremium]);
 
   const handleResetNorth = useCallback(() => {
     mapInstanceRef.current?.getView().animate({ rotation: 0, duration: 300 });
@@ -254,8 +512,9 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
     setMapReady(true);
     // In planner mode always restore stored position (the planner fit effect will override
     // this with the route bounds if there are waypoints). In browse mode only restore when
-    // there are no activities so the activity list auto-fit can take over.
-    if (initialMode === 'planner' || allActivities.length === 0) {
+    // there are no activities so the activity list auto-fit can take over. Premium restores
+    // its view separately (see the premiumInitialView effect above) once the fetch resolves.
+    if (!isPremium && (initialMode === 'planner' || allActivities.length === 0)) {
       const stored = loadRoute();
       if (stored?.mapCenter && isValidBNG(stored.mapCenter as [number, number])) {
         map.getView().setCenter(stored.mapCenter);
@@ -268,11 +527,17 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
       const view = map.getView();
       const center = view.getCenter() as [number, number];
       const zoom = view.getZoom() ?? 7;
-      if (center) saveRoute(waypointsRef.current, segmentsRef.current, center, zoom);
+      if (center) {
+        if (isPremium) {
+          schedulePremiumSave();
+        } else {
+          saveRoute({ actions: actionsRef.current, cursor: cursorRef.current, mapCenter: center, mapZoom: zoom });
+        }
+      }
       setCompassBearing(view.getRotation() * 180 / Math.PI);
       setMapResolution(view.getResolution() ?? 10);
     });
-  }, [allActivities.length, initialMode]);
+  }, [allActivities.length, initialMode, isPremium, schedulePremiumSave]);
 
   // On initial /planner load, fit the map to the saved route once both the map and
   // waypoints are ready. Runs once — no animation so it snaps cleanly on load.
@@ -524,20 +789,39 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
           )}
           {mode === 'planner' && (
             <div className="panel-fade-in" style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-              <PlannerPanel
-                distance={distance}
-                elevGain={elevGain}
-                waypoints={waypoints}
-                segments={segments}
-                elevationData={elevationData}
-                isLoadingElevation={isLoadingElevation}
-                dispatch={dispatch}
-                onFitToRoute={() => handleFitToRoute(waypoints)}
-                onExportImage={handleExportImage}
-                isExportingImage={isExportingImage}
-                onEditWaypoint={handleEditWaypoint}
-                onElevationHover={handleElevationHover}
-              />
+              {isPremium && (
+                <SavedRoutesPicker
+                  loading={!routeHydrated}
+                  routeName={routeMeta.name}
+                  routeLocation={routeMeta.location}
+                  isLocating={isLocating}
+                  saveStatus={saveStatus}
+                  routes={displayRoutesList}
+                  activeRouteId={routeMeta.id}
+                  onSelectRoute={handleSelectRoute}
+                  onCreateRoute={handleCreateNewRoute}
+                  onRenameActive={handleRenameActive}
+                  onRenameRoute={handleRenameRoute}
+                  onDuplicateRoute={handleDuplicateRoute}
+                  onDeleteRoute={handleDeleteRoute}
+                />
+              )}
+              <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+                <PlannerPanel
+                  distance={distance}
+                  elevGain={elevGain}
+                  waypoints={waypoints}
+                  segments={segments}
+                  elevationData={elevationData}
+                  isLoadingElevation={isLoadingElevation}
+                  dispatch={dispatch}
+                  onFitToRoute={() => handleFitToRoute(waypoints)}
+                  onExportImage={handleExportImage}
+                  isExportingImage={isExportingImage}
+                  onEditWaypoint={handleEditWaypoint}
+                  onElevationHover={handleElevationHover}
+                />
+              </div>
             </div>
           )}
           {mode === 'about' && (
@@ -718,6 +1002,8 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
       {/* Planner HUD — always mounted, crossfades in when entering planner */}
       {(() => {
         const distKm = (distance / 1000).toFixed(1);
+        const { label: routeLabel, isPlaceholder: routeLabelIsPlaceholder } = displayRouteLabel({ name: routeMeta.name, location: routeMeta.location });
+        const usingLocationAsName = routeMeta.name === UNTITLED_ROUTE_NAME && !!routeMeta.location;
         return (
           <div style={{
             position: 'fixed', bottom: 10, left: 10, right: 10,
@@ -734,6 +1020,47 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
             transform: mode === 'planner' ? 'translateY(0)' : 'translateY(100%)',
             transition: plannerHudDragging ? 'none' : 'height 0.3s ease, opacity 0.28s ease, transform 0.28s ease',
           }}>
+                {isPremium && (
+                  <>
+                    <style>{`@keyframes skeleton-pulse { 0%, 100% { opacity: .5; } 50% { opacity: .15; } }`}</style>
+                    {routeHydrated ? (
+                      <div
+                        onClick={() => setMobileRoutesSheetOpen(true)}
+                        style={{
+                          flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8,
+                          padding: '10px 16px 0', cursor: 'pointer',
+                        }}
+                      >
+                        <span style={{
+                          font: '600 11px/1.3 var(--mono)', color: routeLabelIsPlaceholder ? 'var(--fog-dim)' : 'var(--ice)',
+                          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                        }}>
+                          {routeLabel}
+                        </span>
+                        {!usingLocationAsName && (routeMeta.location || isLocating) && (
+                          <span style={{ display: 'flex', alignItems: 'center', gap: 3, font: '400 9px/1 var(--mono)', color: 'var(--fog-dim)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}>
+                            {routeMeta.location && <MapPin size={9} style={{ flexShrink: 0 }} />}
+                            {routeMeta.location ?? 'Locating…'}
+                          </span>
+                        )}
+                        <div style={{ flex: 1 }} />
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 4, font: '500 8px/1 var(--mono)', letterSpacing: '.08em', textTransform: 'uppercase', color: 'var(--fog-dim)', flexShrink: 0 }}>
+                          <div style={{
+                            width: 5, height: 5, borderRadius: '50%',
+                            background: saveStatus === 'saving' ? 'var(--fog-dim)' : 'var(--grn)',
+                            boxShadow: saveStatus === 'saving' ? 'none' : '0 0 4px var(--grn)',
+                          }} />
+                          {saveStatus === 'saving' ? 'Saving…' : 'Saved'}
+                        </div>
+                        <ChevronRight size={13} style={{ color: 'var(--fog-dim)', flexShrink: 0 }} />
+                      </div>
+                    ) : (
+                      <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', padding: '10px 16px 0' }}>
+                        <div style={{ width: 110, height: 11, borderRadius: 2, background: 'var(--p3)', animation: 'skeleton-pulse 1.4s ease-in-out infinite' }} />
+                      </div>
+                    )}
+                  </>
+                )}
                 {/* Drag zone — handle bar + stats row, large touch target */}
                 <div
                   onTouchStart={handlePlannerHudTouchStart}
@@ -816,6 +1143,21 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
           waypoints={waypoints}
           onFitToRoute={handleFitToRoute}
           fileInputRef={mobileFileInputRef}
+        />,
+        document.body,
+      )}
+
+      {/* Mobile "My Routes" sheet — premium only */}
+      {mobileRoutesSheetOpen && isPremium && createPortal(
+        <MobileRoutesSheet
+          routes={displayRoutesList}
+          activeRouteId={routeMeta.id}
+          onClose={() => setMobileRoutesSheetOpen(false)}
+          onSelectRoute={handleSelectRoute}
+          onCreateRoute={handleCreateNewRoute}
+          onRenameRoute={handleRenameRoute}
+          onDuplicateRoute={handleDuplicateRoute}
+          onDeleteRoute={handleDeleteRoute}
         />,
         document.body,
       )}

--- a/app/components/shell/MapShell.tsx
+++ b/app/components/shell/MapShell.tsx
@@ -188,12 +188,15 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
   // matching the existing dual-trigger local autosave pattern.
   const schedulePremiumSave = useCallback(() => {
     if (!isPremium || !routeMetaRef.current.id) return;
+    // Clear any pending save before the suppress check — otherwise a save left over from
+    // the route we just switched away from (still in-flight within its debounce window)
+    // fires later and issues a redundant PUT against the newly-active route.
+    if (premiumSaveTimerRef.current) clearTimeout(premiumSaveTimerRef.current);
     if (suppressNextAutosaveRef.current) {
       suppressNextAutosaveRef.current = false;
       return;
     }
     setSaveStatus('saving');
-    if (premiumSaveTimerRef.current) clearTimeout(premiumSaveTimerRef.current);
     premiumSaveTimerRef.current = setTimeout(() => {
       const id = routeMetaRef.current.id;
       if (!id) return;

--- a/app/components/shell/MobileRoutesSheet.tsx
+++ b/app/components/shell/MobileRoutesSheet.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { X, Plus } from 'lucide-react';
+import type { RouteSummary } from '@/lib/saved-routes';
+import RouteListRows from './RouteListRows';
+
+interface MobileRoutesSheetProps {
+  routes: RouteSummary[];
+  activeRouteId: string | null;
+  onClose: () => void;
+  onSelectRoute: (id: string) => void;
+  onCreateRoute: () => void;
+  onRenameRoute: (id: string, name: string) => void;
+  onDuplicateRoute: (id: string) => void;
+  onDeleteRoute: (id: string) => void;
+}
+
+export default function MobileRoutesSheet({
+  routes, activeRouteId, onClose, onSelectRoute, onCreateRoute, onRenameRoute, onDuplicateRoute, onDeleteRoute,
+}: MobileRoutesSheetProps) {
+  return (
+    <>
+      <div onClick={onClose} style={{ position: 'fixed', inset: 0, zIndex: 44, background: 'rgba(0,0,0,0.35)' }} />
+      <div
+        style={{
+          position: 'fixed', left: 10, right: 10, bottom: 10, maxHeight: '70vh',
+          background: 'var(--p1)', border: '1px solid var(--p3)', borderRadius: 16,
+          boxShadow: '0 -4px 24px rgba(0,0,0,.35)', zIndex: 45,
+          display: 'flex', flexDirection: 'column', overflow: 'hidden',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', padding: '14px 16px 10px', flexShrink: 0, borderBottom: '1px solid var(--fog-ghost)' }}>
+          <span style={{ flex: 1, font: '700 11px/1 var(--mono)', letterSpacing: '.08em', textTransform: 'uppercase', color: 'var(--ice)' }}>
+            My Routes{routes.length > 0 ? ` · ${routes.length}` : ''}
+          </span>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 4, color: 'var(--fog-dim)', lineHeight: 0 }}
+          >
+            <X size={16} strokeWidth={2.5} />
+          </button>
+        </div>
+
+        <div style={{ overflowY: 'auto', flex: 1 }}>
+          <RouteListRows
+            routes={routes}
+            activeRouteId={activeRouteId}
+            onSelect={(id) => { onSelectRoute(id); onClose(); }}
+            onRename={onRenameRoute}
+            onDuplicate={onDuplicateRoute}
+            onDelete={onDeleteRoute}
+          />
+        </div>
+
+        <button
+          onClick={() => { onCreateRoute(); onClose(); }}
+          style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+            padding: '14px', borderTop: '1px solid var(--fog-ghost)', background: 'none',
+            color: 'var(--ora)', font: '700 10px/1 var(--mono)', letterSpacing: '.1em', textTransform: 'uppercase',
+            cursor: 'pointer', flexShrink: 0,
+          }}
+        >
+          <Plus size={14} />
+          New route
+        </button>
+      </div>
+    </>
+  );
+}

--- a/app/components/shell/RouteListRows.tsx
+++ b/app/components/shell/RouteListRows.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { MoreVertical, Check, Route as RouteIcon } from 'lucide-react';
+import { displayRouteLabel, type RouteSummary } from '@/lib/saved-routes';
+import DeleteRouteConfirm from './DeleteRouteConfirm';
+
+interface RouteListRowsProps {
+  routes: RouteSummary[];
+  activeRouteId: string | null;
+  onSelect: (id: string) => void;
+  onRename: (id: string, name: string) => void;
+  onDuplicate: (id: string) => void;
+  onDelete: (id: string) => void;
+}
+
+function relativeTime(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const mins = Math.round(diffMs / 60000);
+  if (mins < 1) return 'Just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 14) return `${days}d ago`;
+  return `${Math.round(days / 7)}w ago`;
+}
+
+function fmtDist(m: number): string {
+  return `${(m / 1000).toFixed(1)} km`;
+}
+
+// Positions a fixed-position popover of `width` below-right of `anchor`, flipping above
+// when there isn't room below and clamping horizontally to stay on-screen. Mirrors the
+// positioning logic already used by ImportRoutePopover.
+function popoverPosition(anchor: DOMRect, width: number, height: number) {
+  const left = Math.min(Math.max(8, anchor.right - width), window.innerWidth - width - 8);
+  const spaceBelow = window.innerHeight - anchor.bottom;
+  const top = spaceBelow < height + 8 ? anchor.top - height - 4 : anchor.bottom + 4;
+  return { top, left };
+}
+
+export default function RouteListRows({ routes, activeRouteId, onSelect, onRename, onDuplicate, onDelete }: RouteListRowsProps) {
+  const [menuFor, setMenuFor] = useState<{ id: string; anchor: DOMRect } | null>(null);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState<{ id: string; anchor: DOMRect } | null>(null);
+
+  function commitRename(id: string) {
+    const trimmed = renameValue.trim();
+    if (trimmed) onRename(id, trimmed);
+    setRenamingId(null);
+  }
+
+  if (routes.length === 0) {
+    return (
+      <div style={{ padding: '28px 20px 24px', display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center', gap: 10 }}>
+        <div style={{ width: 34, height: 34, borderRadius: '50%', background: 'var(--p2)', border: '1px solid var(--p3)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--fog-dim)' }}>
+          <RouteIcon size={16} />
+        </div>
+        <div style={{ font: '600 10px/1.4 var(--mono)', color: 'var(--fog)' }}>No saved routes yet</div>
+        <div style={{ font: '400 9px/1.5 var(--mono)', color: 'var(--fog-dim)', maxWidth: 200 }}>Start plotting to create one.</div>
+      </div>
+    );
+  }
+
+  const menuRoute = menuFor ? routes.find((r) => r.id === menuFor.id) : null;
+  const confirmRoute = confirmDelete ? routes.find((r) => r.id === confirmDelete.id) : null;
+
+  return (
+    <div className="route-list-scroll" style={{ maxHeight: 320, overflowY: 'auto' }}>
+      <style>{`
+        .route-list-scroll { scrollbar-width: thin; scrollbar-color: var(--p3) transparent; }
+        .route-list-scroll::-webkit-scrollbar { width: 6px; }
+        .route-list-scroll::-webkit-scrollbar-track { background: transparent; }
+        .route-list-scroll::-webkit-scrollbar-thumb { background: var(--p3); border-radius: 3px; }
+      `}</style>
+      {routes.map((route) => {
+        const isCurrent = route.id === activeRouteId;
+        const { label, isPlaceholder } = displayRouteLabel(route);
+        const isRenaming = renamingId === route.id;
+        return (
+          <div
+            key={route.id}
+            onClick={() => !isRenaming && onSelect(route.id)}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 10, padding: '8px 12px',
+              cursor: isRenaming ? 'default' : 'pointer',
+              background: isCurrent ? 'rgba(224,112,32,0.07)' : 'transparent',
+            }}
+          >
+            <div style={{ width: 13, height: 13, flexShrink: 0, color: 'var(--ora)' }}>
+              {isCurrent && <Check size={13} strokeWidth={2.5} />}
+            </div>
+            <div style={{
+              width: 26, height: 26, borderRadius: 4, background: 'var(--p2)', border: '1px solid var(--p3)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              color: isPlaceholder ? 'var(--fog-dim)' : 'var(--ora)', flexShrink: 0,
+            }}>
+              <RouteIcon size={13} />
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              {isRenaming ? (
+                <input
+                  autoFocus
+                  value={renameValue}
+                  onClick={(e) => e.stopPropagation()}
+                  onChange={(e) => setRenameValue(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') commitRename(route.id);
+                    if (e.key === 'Escape') setRenamingId(null);
+                  }}
+                  onBlur={() => commitRename(route.id)}
+                  style={{
+                    width: '100%', background: 'transparent', border: 'none', borderBottom: '1px solid var(--ora)',
+                    outline: 'none', font: '600 10px/1.3 var(--mono)', color: 'var(--ice)', padding: '0 0 2px',
+                  }}
+                />
+              ) : (
+                <>
+                  <div style={{
+                    font: '600 10px/1.3 var(--mono)', color: isPlaceholder ? 'var(--fog-dim)' : 'var(--ice)',
+                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                  }}>
+                    {label}
+                  </div>
+                  <div style={{ font: '400 8px/1 var(--mono)', color: 'var(--fog-dim)', marginTop: 3 }}>
+                    {fmtDist(route.distanceM)} · {relativeTime(route.updatedAt)}
+                  </div>
+                </>
+              )}
+            </div>
+            {!isRenaming && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const anchor = (e.currentTarget as HTMLButtonElement).getBoundingClientRect();
+                  setMenuFor(menuFor?.id === route.id ? null : { id: route.id, anchor });
+                }}
+                aria-label="Route options"
+                style={{
+                  width: 22, height: 22, borderRadius: 3, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  color: 'var(--fog-dim)', background: 'transparent', border: 'none', cursor: 'pointer', flexShrink: 0,
+                }}
+              >
+                <MoreVertical size={13} />
+              </button>
+            )}
+          </div>
+        );
+      })}
+
+      {menuFor && menuRoute && createPortal(
+        (() => {
+          const { top, left } = popoverPosition(menuFor.anchor, 138, 96);
+          return (
+            <>
+              <div onClick={() => setMenuFor(null)} style={{ position: 'fixed', inset: 0, zIndex: 49 }} />
+              <div
+                style={{
+                  position: 'fixed', top, left, minWidth: 138,
+                  background: 'var(--glass-hvy)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)',
+                  border: '1px solid var(--p3)', borderRadius: 5, padding: 4, zIndex: 50, boxShadow: '0 8px 24px rgba(0,0,0,0.55)',
+                }}
+              >
+                <div
+                  onClick={() => { setRenamingId(menuFor.id); setRenameValue(menuRoute.name); setMenuFor(null); }}
+                  style={{ padding: '7px 8px', borderRadius: 3, font: '500 9.5px/1 var(--mono)', color: 'var(--fog)', cursor: 'pointer' }}
+                >
+                  Rename
+                </div>
+                <div
+                  onClick={() => { onDuplicate(menuFor.id); setMenuFor(null); }}
+                  style={{ padding: '7px 8px', borderRadius: 3, font: '500 9.5px/1 var(--mono)', color: 'var(--fog)', cursor: 'pointer' }}
+                >
+                  Duplicate
+                </div>
+                <div style={{ height: 1, background: 'var(--fog-ghost)', margin: '4px 2px' }} />
+                <div
+                  onClick={(e) => {
+                    const anchor = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
+                    setConfirmDelete({ id: menuFor.id, anchor });
+                    setMenuFor(null);
+                  }}
+                  style={{ padding: '7px 8px', borderRadius: 3, font: '500 9.5px/1 var(--mono)', color: 'rgba(220,80,80,0.85)', cursor: 'pointer' }}
+                >
+                  Delete
+                </div>
+              </div>
+            </>
+          );
+        })(),
+        document.body,
+      )}
+
+      {confirmDelete && confirmRoute && createPortal(
+        (() => {
+          const { top, left } = popoverPosition(confirmDelete.anchor, 208, 90);
+          return (
+            <>
+              <div onClick={() => setConfirmDelete(null)} style={{ position: 'fixed', inset: 0, zIndex: 49 }} />
+              <div style={{ position: 'fixed', top, left, zIndex: 50 }}>
+                <DeleteRouteConfirm
+                  name={confirmRoute.name}
+                  onCancel={() => setConfirmDelete(null)}
+                  onConfirm={() => { onDelete(confirmDelete.id); setConfirmDelete(null); }}
+                />
+              </div>
+            </>
+          );
+        })(),
+        document.body,
+      )}
+    </div>
+  );
+}

--- a/app/components/shell/RouteListRows.tsx
+++ b/app/components/shell/RouteListRows.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { MoreVertical, Check, Route as RouteIcon } from 'lucide-react';
 import { displayRouteLabel, type RouteSummary } from '@/lib/saved-routes';
@@ -46,10 +46,22 @@ export default function RouteListRows({ routes, activeRouteId, onSelect, onRenam
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const [confirmDelete, setConfirmDelete] = useState<{ id: string; anchor: DOMRect } | null>(null);
+  // Escape unmounts the focused <input>, which fires a native blur — guard commitRename
+  // (called from onBlur) against treating that as a save.
+  const renameCancelledRef = useRef(false);
 
   function commitRename(id: string) {
+    if (renameCancelledRef.current) {
+      renameCancelledRef.current = false;
+      return;
+    }
     const trimmed = renameValue.trim();
     if (trimmed) onRename(id, trimmed);
+    setRenamingId(null);
+  }
+
+  function cancelRename() {
+    renameCancelledRef.current = true;
     setRenamingId(null);
   }
 
@@ -109,7 +121,7 @@ export default function RouteListRows({ routes, activeRouteId, onSelect, onRenam
                   onChange={(e) => setRenameValue(e.target.value)}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') commitRename(route.id);
-                    if (e.key === 'Escape') setRenamingId(null);
+                    if (e.key === 'Escape') cancelRename();
                   }}
                   onBlur={() => commitRename(route.id)}
                   style={{

--- a/app/components/shell/SavedRoutesPicker.tsx
+++ b/app/components/shell/SavedRoutesPicker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { ChevronDown, MapPin, Plus, Pencil, Route as RouteIcon } from 'lucide-react';
 import { displayRouteLabel, UNTITLED_ROUTE_NAME, type RouteSummary } from '@/lib/saved-routes';
 import RouteListRows from './RouteListRows';
@@ -28,6 +28,9 @@ export default function SavedRoutesPicker({
   const [open, setOpen] = useState(false);
   const [renaming, setRenaming] = useState(false);
   const [nameValue, setNameValue] = useState(routeName);
+  // Escape unmounts the focused <input>, which fires a native blur — guard commitRename
+  // (called from onBlur) against treating that as a save.
+  const renameCancelledRef = useRef(false);
 
   const { label, isPlaceholder } = displayRouteLabel({ name: routeName, location: routeLocation });
   // When the header is already showing the location in place of a name, the subline
@@ -41,8 +44,17 @@ export default function SavedRoutesPicker({
   }
 
   function commitRename() {
+    if (renameCancelledRef.current) {
+      renameCancelledRef.current = false;
+      return;
+    }
     const trimmed = nameValue.trim();
     if (trimmed && trimmed !== routeName) onRenameActive(trimmed);
+    setRenaming(false);
+  }
+
+  function cancelRename() {
+    renameCancelledRef.current = true;
     setRenaming(false);
   }
 
@@ -86,7 +98,7 @@ export default function SavedRoutesPicker({
             onChange={(e) => setNameValue(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === 'Enter') commitRename();
-              if (e.key === 'Escape') setRenaming(false);
+              if (e.key === 'Escape') cancelRename();
             }}
             onBlur={commitRename}
             style={{

--- a/app/components/shell/SavedRoutesPicker.tsx
+++ b/app/components/shell/SavedRoutesPicker.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, MapPin, Plus, Pencil, Route as RouteIcon } from 'lucide-react';
+import { displayRouteLabel, UNTITLED_ROUTE_NAME, type RouteSummary } from '@/lib/saved-routes';
+import RouteListRows from './RouteListRows';
+
+interface SavedRoutesPickerProps {
+  loading?: boolean;
+  routeName: string;
+  routeLocation: string | null;
+  isLocating?: boolean;
+  saveStatus: 'idle' | 'saving' | 'saved';
+  routes: RouteSummary[];
+  activeRouteId: string | null;
+  onSelectRoute: (id: string) => void;
+  onCreateRoute: () => void;
+  onRenameActive: (name: string) => void;
+  onRenameRoute: (id: string, name: string) => void;
+  onDuplicateRoute: (id: string) => void;
+  onDeleteRoute: (id: string) => void;
+}
+
+export default function SavedRoutesPicker({
+  loading = false, routeName, routeLocation, isLocating = false, saveStatus, routes, activeRouteId,
+  onSelectRoute, onCreateRoute, onRenameActive, onRenameRoute, onDuplicateRoute, onDeleteRoute,
+}: SavedRoutesPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [nameValue, setNameValue] = useState(routeName);
+
+  const { label, isPlaceholder } = displayRouteLabel({ name: routeName, location: routeLocation });
+  // When the header is already showing the location in place of a name, the subline
+  // below shouldn't repeat it.
+  const usingLocationAsName = routeName === UNTITLED_ROUTE_NAME && !!routeLocation;
+
+  function startRename() {
+    setNameValue(routeName);
+    setRenaming(true);
+    setOpen(false);
+  }
+
+  function commitRename() {
+    const trimmed = nameValue.trim();
+    if (trimmed && trimmed !== routeName) onRenameActive(trimmed);
+    setRenaming(false);
+  }
+
+  if (loading) {
+    return (
+      <div style={{ flexShrink: 0, borderBottom: '1px solid var(--fog-ghost)' }}>
+        <style>{`@keyframes skeleton-pulse { 0%, 100% { opacity: .5; } 50% { opacity: .15; } }`}</style>
+        <div style={{ height: 44, display: 'flex', alignItems: 'center', gap: 9, padding: '0 14px' }}>
+          <div style={{ width: 22, height: 22, borderRadius: 4, background: 'var(--p3)', flexShrink: 0, animation: 'skeleton-pulse 1.4s ease-in-out infinite' }} />
+          <div style={{ width: 110, height: 11, borderRadius: 2, background: 'var(--p3)', animation: 'skeleton-pulse 1.4s ease-in-out infinite' }} />
+        </div>
+        <div style={{ padding: '0 14px 8px' }}>
+          <div style={{ width: 70, height: 9, borderRadius: 2, background: 'var(--p3)', animation: 'skeleton-pulse 1.4s ease-in-out infinite' }} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ flexShrink: 0, borderBottom: '1px solid var(--fog-ghost)', position: 'relative' }}>
+      <style>{`@keyframes pulse-dot { 0%, 100% { opacity: 1; } 50% { opacity: .25; } }`}</style>
+      <div
+        onClick={() => !renaming && setOpen((v) => !v)}
+        style={{
+          height: 44, display: 'flex', alignItems: 'center', gap: 9, padding: '0 14px',
+          cursor: renaming ? 'default' : 'pointer', background: open ? 'var(--p2)' : 'transparent',
+        }}
+      >
+        <div style={{
+          width: 22, height: 22, borderRadius: 4, background: 'var(--p2)', border: '1px solid var(--p3)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          color: isPlaceholder ? 'var(--fog-dim)' : 'var(--ora)', flexShrink: 0,
+        }}>
+          <RouteIcon size={14} />
+        </div>
+        {renaming ? (
+          <input
+            autoFocus
+            value={nameValue}
+            onClick={(e) => e.stopPropagation()}
+            onChange={(e) => setNameValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitRename();
+              if (e.key === 'Escape') setRenaming(false);
+            }}
+            onBlur={commitRename}
+            style={{
+              flex: 1, minWidth: 0, background: 'transparent', border: 'none', borderBottom: '1px solid var(--ora)',
+              outline: 'none', font: '600 11px/1.3 var(--mono)', color: 'var(--ice)', padding: '0 0 3px',
+            }}
+          />
+        ) : (
+          <div style={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 6 }} onClick={(e) => { e.stopPropagation(); startRename(); }}>
+            <span style={{
+              font: '600 11px/1.3 var(--mono)', color: isPlaceholder ? 'var(--fog-dim)' : 'var(--ice)',
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>
+              {label}
+            </span>
+            <Pencil size={10} style={{ color: 'var(--fog-dim)', flexShrink: 0, opacity: 0.7 }} />
+          </div>
+        )}
+        {!renaming && (
+          <ChevronDown
+            size={14}
+            style={{ color: open ? 'var(--ora)' : 'var(--fog-dim)', flexShrink: 0, transition: 'transform .15s', transform: open ? 'rotate(180deg)' : 'none' }}
+          />
+        )}
+
+        {open && (
+          <>
+            <div onClick={(e) => { e.stopPropagation(); setOpen(false); }} style={{ position: 'fixed', inset: 0, zIndex: 39 }} />
+            <div
+              onClick={(e) => e.stopPropagation()}
+              style={{
+                position: 'absolute', top: 44, left: 8, right: 8,
+                background: 'var(--glass-hvy)', backdropFilter: 'blur(14px)', border: '1px solid var(--p3)',
+                borderRadius: 6, boxShadow: '0 12px 32px rgba(0,0,0,0.55)', zIndex: 40, overflow: 'hidden',
+              }}
+            >
+              <div style={{ padding: '10px 12px 8px', font: '600 8px/1 var(--mono)', letterSpacing: '.16em', textTransform: 'uppercase', color: 'var(--fog-dim)' }}>
+                My Routes{routes.length > 0 ? ` · ${routes.length}` : ''}
+              </div>
+              <RouteListRows
+                routes={routes}
+                activeRouteId={activeRouteId}
+                onSelect={(id) => { onSelectRoute(id); setOpen(false); }}
+                onRename={onRenameRoute}
+                onDuplicate={onDuplicateRoute}
+                onDelete={onDeleteRoute}
+              />
+              <div
+                onClick={() => { onCreateRoute(); setOpen(false); }}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 8, padding: '11px 12px',
+                  borderTop: '1px solid var(--fog-ghost)', cursor: 'pointer', color: 'var(--ora)',
+                  font: '600 9px/1 var(--mono)', letterSpacing: '.1em', textTransform: 'uppercase',
+                }}
+              >
+                <Plus size={13} />
+                New route
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      {!renaming && (
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, padding: '0 14px 8px' }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 4, font: '400 9px/1 var(--mono)', color: 'var(--fog-dim)',
+            letterSpacing: '.04em', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0,
+          }}>
+            {!usingLocationAsName && (
+              <>
+                {routeLocation && <MapPin size={10} style={{ flexShrink: 0 }} />}
+                {routeLocation ?? (isLocating ? 'Locating…' : '')}
+              </>
+            )}
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 5, font: '500 8px/1 var(--mono)', letterSpacing: '.08em', textTransform: 'uppercase', color: 'var(--fog-dim)', flexShrink: 0 }}>
+            <div style={{
+              width: 5, height: 5, borderRadius: '50%',
+              background: saveStatus === 'saving' ? 'var(--fog-dim)' : 'var(--grn)',
+              boxShadow: saveStatus === 'saving' ? 'none' : '0 0 4px var(--grn)',
+              animation: saveStatus === 'saving' ? 'pulse-dot 1s ease-in-out infinite' : 'none',
+            }} />
+            {saveStatus === 'saving' ? 'Saving…' : 'Saved'}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/shell/hooks/usePlannerHud.ts
+++ b/app/components/shell/hooks/usePlannerHud.ts
@@ -2,8 +2,8 @@
 
 import { useState, useCallback, useRef } from 'react';
 
-export const PLANNER_HUD_COLLAPSED = 60;
-export const PLANNER_HUD_EXPANDED = 168;
+export const PLANNER_HUD_COLLAPSED = 90;
+export const PLANNER_HUD_EXPANDED = 185;
 
 export function usePlannerHud() {
   const [plannerHudHeight, setPlannerHudHeight] = useState(PLANNER_HUD_EXPANDED);

--- a/lib/active-route.ts
+++ b/lib/active-route.ts
@@ -1,0 +1,21 @@
+const ACTIVE_ROUTE_KEY = 'plotv2-active-route-id';
+
+// Which saved route (premium) was last open — just a pointer so reload reopens the same
+// route. This is fine to keep local even under the free-tier zero-backend-footprint rule:
+// it names a route, it isn't route content.
+export function getActiveRouteId(): string | null {
+  try {
+    return localStorage.getItem(ACTIVE_ROUTE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setActiveRouteId(id: string | null): void {
+  try {
+    if (id) localStorage.setItem(ACTIVE_ROUTE_KEY, id);
+    else localStorage.removeItem(ACTIVE_ROUTE_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/lib/route-actions.ts
+++ b/lib/route-actions.ts
@@ -1,0 +1,192 @@
+import { Waypoint, RouteSegment } from './types';
+
+export interface RouteState {
+  waypoints: Waypoint[];
+  segments: RouteSegment[];
+}
+
+export const EMPTY_ROUTE_STATE: RouteState = { waypoints: [], segments: [] };
+
+// Content-changing actions — the only things ever appended to a route's persisted
+// action log. UNDO/REDO/RESTORE (in useRouteHistory.ts) move the cursor over this
+// log but are never themselves logged.
+export type RouteContentAction =
+  | { type: 'ADD_WAYPOINT'; waypoint: Waypoint; snap?: boolean }
+  | { type: 'INSERT_WAYPOINT'; index: number; waypoint: Waypoint; snap?: boolean }
+  | { type: 'MOVE_WAYPOINT'; index: number; waypoint: Waypoint }
+  | { type: 'REMOVE_WAYPOINT'; index: number }
+  | { type: 'CLEAR' }
+  | { type: 'LOAD'; waypoints: Waypoint[]; segments?: RouteSegment[] }
+  | { type: 'UPDATE_SEGMENT'; index: number; coordinates: Waypoint[]; distance?: number }
+  | { type: 'TOGGLE_SEGMENT_SNAP'; index: number }
+  | { type: 'REVERSE' };
+
+/**
+ * Pure state transition for a single content action. Returns null when the action
+ * doesn't apply to the given state (e.g. CLEAR on an already-empty route) — callers
+ * treat null as "no-op, don't record this".
+ */
+export function applyAction(state: RouteState, action: RouteContentAction): RouteState | null {
+  switch (action.type) {
+    case 'ADD_WAYPOINT': {
+      const newSegments = [...state.segments];
+      if (state.waypoints.length > 0) {
+        newSegments.push({
+          snapped: action.snap ?? false,
+          coordinates: [],
+        });
+      }
+      return {
+        waypoints: [...state.waypoints, action.waypoint],
+        segments: newSegments,
+      };
+    }
+    case 'INSERT_WAYPOINT': {
+      const { index, waypoint } = action;
+      const newWaypoints = [
+        ...state.waypoints.slice(0, index),
+        waypoint,
+        ...state.waypoints.slice(index),
+      ];
+
+      const newSegments = [...state.segments];
+      if (state.waypoints.length < 2) {
+        // Was 0 or 1 waypoint, inserting makes it 2 — add a segment
+        if (newWaypoints.length >= 2) {
+          newSegments.push({
+            snapped: action.snap ?? false,
+            coordinates: [],
+          });
+        }
+      } else {
+        // Split the segment at (index - 1) into two
+        const segIdx = Math.max(0, index - 1);
+        const original = newSegments[segIdx];
+        const inheritSnap = action.snap ?? original?.snapped ?? false;
+        newSegments.splice(segIdx, 1,
+          { snapped: inheritSnap, coordinates: [] },
+          { snapped: inheritSnap, coordinates: [] },
+        );
+      }
+
+      return { waypoints: newWaypoints, segments: newSegments };
+    }
+    case 'MOVE_WAYPOINT': {
+      const newWaypoints = state.waypoints.map((wp, i) =>
+        i === action.index ? action.waypoint : wp
+      );
+      const newSegments = state.segments.map((seg, i) => {
+        // Clear coordinates of adjacent segments (before and after moved waypoint)
+        if (i === action.index - 1 || i === action.index) {
+          return { ...seg, coordinates: [], distance: undefined };
+        }
+        return seg;
+      });
+      return { waypoints: newWaypoints, segments: newSegments };
+    }
+    case 'REMOVE_WAYPOINT': {
+      const { index } = action;
+      const newWaypoints = state.waypoints.filter((_, i) => i !== index);
+      const newSegments = [...state.segments];
+
+      if (state.waypoints.length <= 2) {
+        // Removing takes us to 0 or 1 waypoint — no segments
+        return { waypoints: newWaypoints, segments: [] };
+      }
+
+      if (index === 0) {
+        // Remove first segment
+        newSegments.splice(0, 1);
+      } else if (index === state.waypoints.length - 1) {
+        // Remove last segment
+        newSegments.splice(newSegments.length - 1, 1);
+      } else {
+        // Merge segments[index-1] and segments[index] into one
+        const before = newSegments[index - 1];
+        const after = newSegments[index];
+        const merged: RouteSegment = {
+          snapped: before.snapped || after.snapped,
+          coordinates: [],
+        };
+        newSegments.splice(index - 1, 2, merged);
+      }
+
+      return { waypoints: newWaypoints, segments: newSegments };
+    }
+    case 'CLEAR':
+      if (state.waypoints.length === 0) return null;
+      return { waypoints: [], segments: [] };
+    case 'LOAD':
+      return {
+        waypoints: action.waypoints,
+        segments: action.segments ?? [],
+      };
+    case 'UPDATE_SEGMENT': {
+      if (action.index < 0 || action.index >= state.segments.length) return null;
+      const newSegments = state.segments.map((seg, i) => {
+        if (i === action.index) {
+          return {
+            ...seg,
+            coordinates: action.coordinates,
+            distance: action.distance,
+          };
+        }
+        return seg;
+      });
+      return { waypoints: state.waypoints, segments: newSegments };
+    }
+    case 'TOGGLE_SEGMENT_SNAP': {
+      if (action.index < 0 || action.index >= state.segments.length) return null;
+      const newSegments = state.segments.map((seg, i) => {
+        if (i === action.index) {
+          return {
+            snapped: !seg.snapped,
+            coordinates: [],
+            distance: undefined,
+          };
+        }
+        return seg;
+      });
+      return { waypoints: state.waypoints, segments: newSegments };
+    }
+    case 'REVERSE': {
+      if (state.waypoints.length < 2) return null;
+      const waypoints = [...state.waypoints].reverse();
+      const segments = [...state.segments].reverse().map(seg => ({
+        ...seg,
+        coordinates: [...seg.coordinates].reverse(),
+      }));
+      return { waypoints, segments };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Replays the full action log, returning the route state after each prefix —
+ * result[i] = state after actions[0, i). Called once per hydration (LOAD/RESTORE);
+ * useRouteHistory then indexes into this array for O(1) undo/redo instead of
+ * re-walking the log on every cursor move.
+ */
+export function replayAll(actions: RouteContentAction[]): RouteState[] {
+  const states: RouteState[] = [EMPTY_ROUTE_STATE];
+  let state = EMPTY_ROUTE_STATE;
+  for (const action of actions) {
+    const next = applyAction(state, action);
+    if (next) state = next;
+    states.push(state);
+  }
+  return states;
+}
+
+/** One-off, uncached replay to a given cursor — for callers outside the live
+ * history hook (e.g. duplicating a route that isn't the currently-open one). */
+export function replayToCursor(actions: RouteContentAction[], cursor: number): RouteState {
+  let state = EMPTY_ROUTE_STATE;
+  for (let i = 0; i < cursor; i++) {
+    const next = applyAction(state, actions[i]);
+    if (next) state = next;
+  }
+  return state;
+}

--- a/lib/route-persistence.ts
+++ b/lib/route-persistence.ts
@@ -1,0 +1,21 @@
+import type { RouteContentAction } from './route-actions';
+import type { RouteHistoryInit } from '@/app/(main)/planner/useRouteHistory';
+
+/**
+ * The one persisted shape for a route's editing state — action log + cursor (so undo/redo
+ * survives reload without ever re-hitting the routing API) plus the map view the user was
+ * looking at. Free-tier writes this to localStorage (lib/route-storage.ts); premium writes
+ * the identical shape to the backend (lib/saved-routes.ts) — only the storage adapter
+ * differs, not the format.
+ */
+export interface RoutePersistedData {
+  actions: RouteContentAction[];
+  cursor: number;
+  mapCenter: [number, number];
+  mapZoom: number;
+  mapRotation?: number;
+}
+
+export function toHistoryInit(data: Pick<RoutePersistedData, 'actions' | 'cursor'>): RouteHistoryInit {
+  return { actions: data.actions, cursor: data.cursor };
+}

--- a/lib/route-storage.ts
+++ b/lib/route-storage.ts
@@ -1,4 +1,6 @@
 import { Waypoint, RouteSegment } from './types';
+import type { RouteContentAction } from './route-actions';
+import type { RoutePersistedData } from './route-persistence';
 
 const STORAGE_KEY = 'plotv2-planner-route';
 
@@ -20,7 +22,12 @@ interface StoredRouteV2 {
   savedAt: string;
 }
 
-type StoredRoute = StoredRouteV2;
+interface StoredRouteV3 extends RoutePersistedData {
+  version: 3;
+  savedAt: string;
+}
+
+type StoredRoute = StoredRouteV3;
 
 function migrateV1(v1: StoredRouteV1): StoredRouteV2 {
   const segments: RouteSegment[] = [];
@@ -37,28 +44,29 @@ function migrateV1(v1: StoredRouteV1): StoredRouteV2 {
   };
 }
 
-export function saveRoute(
-  waypoints: Waypoint[],
-  segments: RouteSegment[],
-  mapCenter: [number, number],
-  mapZoom: number,
-  mapRotation?: number
-): void {
+// Legacy flat {waypoints, segments} → single-action log. Undo history has never persisted
+// for anyone before this change, so starting fresh here is not a regression.
+function migrateV2(v2: StoredRouteV2): StoredRouteV3 {
+  const loadAction: RouteContentAction = {
+    type: 'LOAD',
+    waypoints: v2.waypoints as Waypoint[],
+    segments: v2.segments,
+  };
+  return {
+    version: 3,
+    actions: [loadAction],
+    cursor: 1,
+    mapCenter: v2.mapCenter,
+    mapZoom: v2.mapZoom,
+    ...(v2.mapRotation != null ? { mapRotation: v2.mapRotation } : {}),
+    savedAt: v2.savedAt,
+  };
+}
+
+export function saveRoute(data: RoutePersistedData): void {
   try {
-    const data: StoredRouteV2 = {
-      version: 2,
-      waypoints: waypoints.map(({ lat, lng, ele }) => ({
-        lat,
-        lng,
-        ...(ele != null ? { ele } : {}),
-      })),
-      segments,
-      mapCenter,
-      mapZoom,
-      ...(mapRotation != null ? { mapRotation } : {}),
-      savedAt: new Date().toISOString(),
-    };
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    const stored: StoredRouteV3 = { version: 3, ...data, savedAt: new Date().toISOString() };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
   } catch {
     // localStorage may be full or unavailable
   }
@@ -69,8 +77,9 @@ export function loadRoute(): StoredRoute | null {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
     const data = JSON.parse(raw);
-    if (data?.version === 1) return migrateV1(data as StoredRouteV1);
-    if (data?.version === 2) return data as StoredRouteV2;
+    if (data?.version === 1) return migrateV2(migrateV1(data as StoredRouteV1));
+    if (data?.version === 2) return migrateV2(data as StoredRouteV2);
+    if (data?.version === 3) return data as StoredRouteV3;
     return null;
   } catch {
     return null;

--- a/lib/saved-routes.ts
+++ b/lib/saved-routes.ts
@@ -1,0 +1,103 @@
+import type { Waypoint, RouteSegment } from './types';
+import type { RouteContentAction } from './route-actions';
+
+export interface RouteSummary {
+  id: string;
+  name: string;
+  location: string | null;
+  distanceM: number;
+  waypointCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RouteDetail extends RouteSummary {
+  actions: RouteContentAction[];
+  cursor: number;
+  mapCenter: [number, number];
+  mapZoom: number;
+  mapRotation?: number;
+}
+
+export const UNTITLED_ROUTE_NAME = 'Untitled route';
+
+/**
+ * What to actually display in place of a route's name: the real name if the user set
+ * one, else its geocoded location (more useful than a bare "Untitled route" when you
+ * have several), else the literal placeholder as a last resort. `isPlaceholder` tells
+ * callers whether they're showing the literal placeholder (dim it) vs real info.
+ */
+export function displayRouteLabel(route: { name: string; location: string | null }): { label: string; isPlaceholder: boolean } {
+  if (route.name !== UNTITLED_ROUTE_NAME) return { label: route.name, isPlaceholder: false };
+  if (route.location) return { label: route.location, isPlaceholder: false };
+  return { label: UNTITLED_ROUTE_NAME, isPlaceholder: true };
+}
+
+export interface RouteUpdatePatch {
+  name?: string;
+  location?: string | null;
+  distanceM: number;
+  waypointCount: number;
+  actions: RouteContentAction[];
+  cursor: number;
+  mapCenter: [number, number];
+  mapZoom: number;
+  mapRotation?: number;
+}
+
+async function parseOrNull<T>(res: Response): Promise<T | null> {
+  if (!res.ok) return null;
+  try {
+    return await res.json() as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function listRoutes(): Promise<RouteSummary[]> {
+  const res = await fetch('/api/routes');
+  const data = await parseOrNull<{ routes: RouteSummary[] }>(res);
+  return data?.routes ?? [];
+}
+
+export async function createRoute(name = 'Untitled route'): Promise<RouteSummary | null> {
+  const res = await fetch('/api/routes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+  return parseOrNull<RouteSummary>(res);
+}
+
+export async function getRoute(id: string): Promise<RouteDetail | null> {
+  const res = await fetch(`/api/routes/${id}`);
+  return parseOrNull<RouteDetail>(res);
+}
+
+export async function updateRoute(id: string, patch: RouteUpdatePatch): Promise<RouteSummary | null> {
+  const res = await fetch(`/api/routes/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  return parseOrNull<RouteSummary>(res);
+}
+
+export async function duplicateRoute(
+  id: string,
+  name: string,
+  waypoints: Waypoint[],
+  segments: RouteSegment[],
+): Promise<RouteSummary | null> {
+  const res = await fetch(`/api/routes/${id}/duplicate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, waypoints, segments }),
+  });
+  return parseOrNull<RouteSummary>(res);
+}
+
+export async function deleteRoute(id: string): Promise<boolean> {
+  const res = await fetch(`/api/routes/${id}`, { method: 'DELETE' });
+  return res.ok;
+}

--- a/mockup-saved-routes-desktop.html
+++ b/mockup-saved-routes-desktop.html
@@ -1,0 +1,637 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>plot — mockup — saved routes — desktop</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Ribeye+Marrow&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --p0: #070E14;
+      --p1: #0E2830;
+      --p2: #163840;
+      --p3: #1E4858;
+      --p4: #2A5860;
+      --ora: #E07020;
+      --grn: #40B060;
+      --blu: #4080C0;
+      --ice: #F0F8FA;
+      --fog: rgba(240,248,250,0.72);
+      --fog-dim: rgba(240,248,250,0.45);
+      --fog-ghost: rgba(240,248,250,0.08);
+      --mono: 'IBM Plex Mono', monospace;
+      --display: 'Ribeye Marrow', cursive;
+      --panel-w: 300px;
+    }
+
+    body { background: #040A0F; color: var(--ice); font-family: var(--mono); min-height: 100vh; }
+
+    /* PAGE CHROME (from mockup-h) */
+    .page-header { padding: 48px 56px 32px; border-bottom: 1px solid var(--fog-ghost); display: flex; align-items: baseline; gap: 24px; }
+    .page-wordmark { font-family: var(--display); font-size: 28px; color: var(--ice); letter-spacing: .02em; }
+    .page-title { font: 600 11px/1 var(--mono); letter-spacing: .16em; text-transform: uppercase; color: var(--fog-dim); }
+    .page-tag { margin-left: auto; font: 400 10px/1 var(--mono); color: var(--p4); letter-spacing: .1em; }
+    .section-header { padding: 40px 56px 20px; }
+    .section-label { font: 600 10px/1 var(--mono); letter-spacing: .2em; text-transform: uppercase; color: var(--ora); margin-bottom: 6px; }
+    .section-desc { font: 400 12px/1.5 var(--mono); color: var(--fog-dim); max-width: 640px; }
+    .frames-row { display: flex; gap: 32px; padding: 0 56px 56px; overflow-x: auto; align-items: flex-start; }
+    .frame-wrap { flex-shrink: 0; }
+    .frame-label { font: 600 9px/1 var(--mono); letter-spacing: .18em; text-transform: uppercase; color: var(--fog-dim); margin-bottom: 10px; }
+    .frame-note { font: 400 9px/1.5 var(--mono); color: var(--p4); letter-spacing: .02em; margin-top: 10px; max-width: 300px; }
+    .frame-border { border: 1px solid var(--p3); border-radius: 4px; overflow: hidden; }
+
+    /* DESKTOP FRAME (from mockup-h) */
+    .desk-frame { width: 1200px; height: 760px; display: flex; position: relative; overflow: hidden; background: var(--p0); }
+
+    /* PANEL (from mockup-h) */
+    .panel { width: var(--panel-w); height: 100%; background: var(--p1); border-right: 1px solid var(--p3); display: flex; flex-direction: column; flex-shrink: 0; position: relative; z-index: 10; }
+    .status-bar { height: 28px; background: var(--p0); display: flex; align-items: center; padding: 0 12px; gap: 8px; border-bottom: 1px solid var(--fog-ghost); flex-shrink: 0; }
+    .status-time { font: 600 10px/1 var(--mono); letter-spacing: .08em; color: var(--fog); }
+    .status-sep { flex: 1; }
+    .status-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--grn); box-shadow: 0 0 4px var(--grn); }
+    .status-synced { font: 400 9px/1 var(--mono); letter-spacing: .06em; color: var(--fog-dim); }
+    .status-avatar { width: 18px; height: 18px; border-radius: 50%; background: var(--p3); border: 1px solid var(--p4); display: flex; align-items: center; justify-content: center; font: 700 7px/1 var(--mono); color: var(--fog); }
+    .panel-hdr { height: 52px; display: flex; align-items: center; padding: 0 16px; border-bottom: 1px solid var(--fog-ghost); flex-shrink: 0; gap: 10px; }
+    .wordmark { font-family: var(--display); font-size: 22px; color: var(--ice); letter-spacing: .02em; flex: 1; }
+    .tab-bar { height: 36px; display: flex; border-bottom: 1px solid var(--fog-ghost); flex-shrink: 0; }
+    .tab { flex: 1; display: flex; align-items: center; justify-content: center; font: 600 9px/1 var(--mono); letter-spacing: .14em; text-transform: uppercase; color: var(--fog-dim); border-bottom: 2px solid transparent; cursor: pointer; }
+    .tab.active { color: var(--ora); border-bottom-color: var(--ora); }
+
+    /* MAP AREA (from mockup-h) */
+    .map-area { flex: 1; position: relative; overflow: hidden; background: var(--p0); }
+    .map-bg { position: absolute; inset: 0; background-image: url('osmapdark.jpg'); background-size: cover; background-position: center; }
+    .map-svg { position: absolute; inset: 0; width: 100%; height: 100%; }
+    .map-compass { position: absolute; bottom: 24px; left: 20px; width: 36px; height: 36px; }
+    .heatmap-overlay { position: absolute; inset: 0; background: radial-gradient(ellipse 60% 40% at 55% 45%, rgba(224,112,32,0.14) 0%, transparent 70%); pointer-events: none; }
+    .layers-btn { position: absolute; bottom: 16px; left: 12px; z-index: 12; width: 44px; height: 44px; border-radius: 8px; background: rgba(7,14,20,0.88); backdrop-filter: blur(8px); border: 1px solid var(--p3); display: flex; align-items: center; justify-content: center; cursor: pointer; color: var(--fog-dim); box-shadow: 0 2px 8px rgba(0,0,0,0.4); }
+
+    /* PLANNER TOOLBAR (from mockup-h) */
+    .planner-toolbar { position: absolute; top: 0; left: 0; right: 0; height: 44px; background: rgba(7,14,20,0.92); backdrop-filter: blur(12px); border-bottom: 1px solid var(--p3); display: flex; align-items: center; padding: 0 12px; gap: 2px; z-index: 5; }
+    .ptb-sep { width: 1px; height: 24px; background: var(--p3); margin: 0 6px; }
+    .ptb-btn { width: 36px; height: 32px; border-radius: 3px; background: transparent; border: none; cursor: pointer; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 2px; color: var(--fog-dim); }
+    .ptb-btn.active { color: var(--ora); }
+    .ptb-btn.disabled { opacity: 0.28; cursor: not-allowed; }
+    .ptb-btn span { font: 600 7px/1 var(--mono); letter-spacing: .06em; text-transform: uppercase; color: inherit; }
+    .ptb-spacer { flex: 1; }
+    .ptb-route-info { font: 600 10px/1 var(--mono); color: var(--fog); letter-spacing: .06em; padding: 0 12px; white-space: nowrap; }
+    .ptb-route-info em { font-style: normal; color: var(--fog-dim); }
+    .ptb-hint { font: 400 10px/1 var(--mono); color: var(--fog-dim); letter-spacing: .04em; padding: 0 12px; white-space: nowrap; }
+
+    /* ROUTE HUD (from mockup-h) */
+    .route-hud { margin: 10px 12px 8px; padding: 12px; background: var(--p2); border: 1px solid var(--p3); border-radius: 4px; }
+    .route-hud-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px 16px; }
+    .route-hud-stat .val { font: 700 16px/1 var(--mono); color: var(--ice); letter-spacing: .02em; }
+    .route-hud-stat .lbl { font: 400 8px/1.4 var(--mono); color: var(--fog-dim); letter-spacing: .08em; text-transform: uppercase; margin-top: 2px; }
+
+    .planner-section-lbl { font: 600 8px/1 var(--mono); letter-spacing: .16em; text-transform: uppercase; color: var(--fog-dim); margin-bottom: 10px; }
+    .planner-new-route-wrap { padding: 14px 14px 0; flex-shrink: 0; }
+    .planner-new-btn { width: 100%; height: 40px; background: var(--ora); border: none; border-radius: 4px; font: 700 10px/1 var(--mono); letter-spacing: .12em; text-transform: uppercase; color: var(--p0); cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 8px; }
+    .detail-btn-secondary { height: 32px; background: transparent; border: 1px solid var(--p3); border-radius: 4px; font: 500 9px/1 var(--mono); letter-spacing: .1em; text-transform: uppercase; color: var(--fog-dim); cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 8px; }
+
+    /* ══════════════════════════════════════════
+       NEW: ROUTE IDENTITY / SAVED-ROUTES LIBRARY
+    ══════════════════════════════════════════ */
+
+    /* Trigger row — sits directly under the tab bar, always visible in Planner mode */
+    .route-switcher { height: 44px; display: flex; align-items: center; gap: 9px; padding: 0 14px; cursor: pointer; border-bottom: 1px solid var(--fog-ghost); flex-shrink: 0; position: relative; }
+    .route-switcher:hover { background: rgba(240,248,250,0.02); }
+    .route-switcher.open { background: var(--p2); }
+    .route-switcher-glyph { width: 22px; height: 22px; border-radius: 4px; background: var(--p2); border: 1px solid var(--p3); display: flex; align-items: center; justify-content: center; color: var(--ora); flex-shrink: 0; }
+    .route-switcher-body { flex: 1; min-width: 0; }
+    .route-switcher-name { font: 600 11px/1.3 var(--mono); color: var(--ice); letter-spacing: .02em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .route-switcher-name.untitled { color: var(--fog-dim); }
+    .route-switcher-label { font: 600 8px/1 var(--mono); letter-spacing: .16em; text-transform: uppercase; color: var(--fog-dim); }
+    .route-switcher-chevron { color: var(--fog-dim); flex-shrink: 0; transition: transform .15s; }
+    .route-switcher.open .route-switcher-chevron { color: var(--ora); transform: rotate(180deg); }
+
+    /* Identity subline — location + autosave state */
+    .route-identity-sub { display: flex; align-items: center; justify-content: space-between; padding: 8px 14px 0; gap: 8px; }
+    .route-location { font: 400 9px/1 var(--mono); color: var(--fog-dim); letter-spacing: .04em; display: flex; align-items: center; gap: 4px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+    .autosave-chip { display: flex; align-items: center; gap: 5px; font: 500 8px/1 var(--mono); letter-spacing: .08em; text-transform: uppercase; color: var(--fog-dim); flex-shrink: 0; }
+    .autosave-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--grn); box-shadow: 0 0 4px var(--grn); flex-shrink: 0; }
+    .autosave-dot.saving { background: var(--fog-dim); box-shadow: none; animation: pulse-dot 1s ease-in-out infinite; }
+    @keyframes pulse-dot { 0%, 100% { opacity: 1; } 50% { opacity: .25; } }
+
+    /* Inline rename input — replaces .route-switcher-name in place */
+    .route-name-input { flex: 1; min-width: 0; background: transparent; border: none; border-bottom: 1px solid var(--ora); outline: none; font: 600 11px/1.3 var(--mono); color: var(--ice); letter-spacing: .02em; padding: 0 0 3px; }
+    .rename-hint { font: 400 8px/1 var(--mono); color: var(--fog-dim); letter-spacing: .04em; padding: 6px 14px 0; }
+
+    /* Flyout — dropdown list of saved routes */
+    .route-flyout { position: absolute; top: 44px; left: 8px; right: 8px; background: rgba(7,14,20,0.97); backdrop-filter: blur(14px); border: 1px solid var(--p3); border-radius: 6px; box-shadow: 0 12px 32px rgba(0,0,0,0.55); z-index: 40; overflow: hidden; }
+    .route-flyout-hdr { padding: 10px 12px 8px; font: 600 8px/1 var(--mono); letter-spacing: .16em; text-transform: uppercase; color: var(--fog-dim); }
+    .route-flyout-list { max-height: 320px; overflow-y: auto; }
+    .route-flyout-item { display: flex; align-items: center; gap: 10px; padding: 8px 12px; cursor: pointer; position: relative; }
+    .route-flyout-item:hover { background: var(--p2); }
+    .route-flyout-item.current { background: rgba(224,112,32,0.07); }
+    .route-item-check { width: 13px; height: 13px; color: var(--ora); flex-shrink: 0; }
+    .route-item-check-ghost { width: 13px; height: 13px; flex-shrink: 0; }
+    .route-item-glyph { width: 26px; height: 26px; border-radius: 4px; background: var(--p2); border: 1px solid var(--p3); display: flex; align-items: center; justify-content: center; color: var(--ora); flex-shrink: 0; }
+    .route-item-glyph.untitled { color: var(--fog-dim); }
+    .route-item-info { flex: 1; min-width: 0; }
+    .route-item-name { font: 600 10px/1.3 var(--mono); color: var(--ice); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .route-item-name.untitled { color: var(--fog-dim); }
+    .route-item-meta { font: 400 8px/1 var(--mono); color: var(--fog-dim); margin-top: 3px; letter-spacing: .03em; }
+    .route-item-overflow-btn { width: 22px; height: 22px; border-radius: 3px; display: flex; align-items: center; justify-content: center; color: var(--fog-dim); background: transparent; border: none; cursor: pointer; flex-shrink: 0; }
+    .route-item-overflow-btn:hover { background: var(--p3); color: var(--fog); }
+    .route-flyout-new { display: flex; align-items: center; gap: 8px; padding: 11px 12px; border-top: 1px solid var(--fog-ghost); cursor: pointer; color: var(--ora); font: 600 9px/1 var(--mono); letter-spacing: .1em; text-transform: uppercase; }
+    .route-flyout-new:hover { background: rgba(224,112,32,0.06); }
+    .route-flyout-empty { padding: 28px 20px 24px; display: flex; flex-direction: column; align-items: center; text-align: center; gap: 10px; }
+    .route-flyout-empty-icon { width: 34px; height: 34px; border-radius: 50%; background: var(--p2); border: 1px solid var(--p3); display: flex; align-items: center; justify-content: center; color: var(--fog-dim); }
+    .route-flyout-empty-title { font: 600 10px/1.4 var(--mono); color: var(--fog); letter-spacing: .02em; }
+    .route-flyout-empty-sub { font: 400 9px/1.5 var(--mono); color: var(--fog-dim); letter-spacing: .02em; max-width: 200px; }
+
+    /* Context menu — rename / duplicate / delete */
+    .ctx-menu { position: absolute; background: rgba(7,14,20,0.97); backdrop-filter: blur(12px); border: 1px solid var(--p3); border-radius: 5px; padding: 4px; min-width: 138px; z-index: 50; box-shadow: 0 8px 24px rgba(0,0,0,0.55); }
+    .ctx-menu-item { display: flex; align-items: center; gap: 8px; padding: 7px 8px; border-radius: 3px; font: 500 9.5px/1 var(--mono); color: var(--fog); letter-spacing: .03em; cursor: pointer; }
+    .ctx-menu-item:hover { background: var(--p2); }
+    .ctx-menu-item.danger { color: rgba(220,80,80,0.85); }
+    .ctx-menu-sep { height: 1px; background: var(--fog-ghost); margin: 4px 2px; }
+
+    /* Delete confirm popover */
+    .confirm-card { position: absolute; background: rgba(7,14,20,0.97); backdrop-filter: blur(12px); border: 1px solid rgba(200,60,60,0.35); border-radius: 5px; padding: 12px; width: 208px; z-index: 50; box-shadow: 0 8px 24px rgba(0,0,0,0.55); }
+    .confirm-card-title { font: 500 10px/1.5 var(--mono); color: var(--fog); letter-spacing: .02em; margin-bottom: 10px; }
+    .confirm-card-title strong { color: var(--ice); font-weight: 600; }
+    .confirm-card-actions { display: flex; gap: 6px; }
+    .confirm-btn { flex: 1; height: 26px; border-radius: 3px; font: 600 8.5px/1 var(--mono); letter-spacing: .06em; text-transform: uppercase; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+    .confirm-btn.cancel { background: transparent; border: 1px solid var(--p3); color: var(--fog-dim); }
+    .confirm-btn.delete { background: rgba(200,60,60,0.85); border: none; color: var(--ice); }
+
+    .storyboard-caption { position: absolute; font: 500 8px/1 var(--mono); letter-spacing: .08em; text-transform: uppercase; color: var(--p4); white-space: nowrap; }
+    .storyboard-caption svg { display: inline; vertical-align: middle; margin-right: 3px; }
+
+    .ico    { width: 16px; height: 16px; display: block; flex-shrink: 0; }
+    .ico-sm { width: 14px; height: 14px; display: block; flex-shrink: 0; }
+    .ico-xs { width: 12px; height: 12px; display: block; flex-shrink: 0; }
+  </style>
+</head>
+<body>
+
+<div class="page-header">
+  <div class="page-wordmark">plot</div>
+  <div class="page-title">Mockup — Saved Routes · Desktop Flows</div>
+  <div class="page-tag">Premium · 2026</div>
+</div>
+
+<div class="section-header">
+  <div class="section-label">Desktop</div>
+  <div class="section-desc">A "My Routes" switcher lives directly under the Planner tab. New routes autosave as "Untitled route" the moment you place the first waypoint — naming is optional, never blocking. Everything below the switcher (stats, waypoints, GPX/Image export) is the existing planner panel, unchanged.</div>
+</div>
+
+<div class="frames-row">
+
+<!-- ════════════════════════════════════════
+     FRAME 01 · NAMED SAVED ROUTE (resting state)
+════════════════════════════════════════ -->
+<div class="frame-wrap">
+  <div class="frame-label">01 — Saved Route · Resting</div>
+  <div class="frame-border"><div class="desk-frame">
+
+    <div class="panel">
+      <div class="status-bar">
+        <span class="status-time">10:14</span><span class="status-sep"></span>
+        <div class="status-dot"></div><span class="status-synced">synced</span>
+        <div class="status-avatar">PC</div>
+      </div>
+      <div class="panel-hdr"><div class="wordmark">plot</div></div>
+      <div class="tab-bar"><div class="tab">Activities</div><div class="tab active">Planner</div></div>
+
+      <!-- Route switcher -->
+      <div class="route-switcher">
+        <div class="route-switcher-glyph"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+        <div class="route-switcher-body"><div class="route-switcher-name">Pentland Skyline</div></div>
+        <svg class="ico-sm route-switcher-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </div>
+      <div class="route-identity-sub">
+        <div class="route-location"><svg class="ico-xs" style="flex-shrink:0;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>Pentland Hills · Edinburgh</div>
+        <div class="autosave-chip"><div class="autosave-dot"></div>Saved</div>
+      </div>
+
+      <!-- Stats + elevation (existing route-hud, unchanged) -->
+      <div class="route-hud">
+        <div class="route-hud-grid">
+          <div class="route-hud-stat"><div class="val">12.4</div><div class="lbl">km</div></div>
+          <div class="route-hud-stat"><div class="val">580</div><div class="lbl">m elev</div></div>
+          <div class="route-hud-stat"><div class="val">3</div><div class="lbl">waypoints</div></div>
+          <div class="route-hud-stat"><div class="val">~4h</div><div class="lbl">est. time</div></div>
+        </div>
+        <div style="position:relative;height:44px;margin-top:10px;border-radius:3px;overflow:hidden;background:var(--p1);border:1px solid var(--p3);">
+          <svg width="100%" height="44" viewBox="0 0 248 44" preserveAspectRatio="none">
+            <defs><linearGradient id="ev01" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#E07020" stop-opacity="0.35"/><stop offset="100%" stop-color="#E07020" stop-opacity="0.02"/></linearGradient></defs>
+            <path d="M0,44 L0,36 C20,34 38,30 56,22 C74,14 86,10 108,8 C130,6 144,12 162,20 C178,27 192,30 210,26 C226,22 238,18 248,16 L248,44 Z" fill="url(#ev01)"/>
+            <path d="M0,36 C20,34 38,30 56,22 C74,14 86,10 108,8 C130,6 144,12 162,20 C178,27 192,30 210,26 C226,22 238,18 248,16" fill="none" stroke="#E07020" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </div>
+      </div>
+
+      <!-- Waypoints -->
+      <div style="padding:4px 14px 4px;flex-shrink:0;"><div class="planner-section-lbl">Waypoints</div></div>
+      <div style="overflow-y:auto;flex:1;padding:0 14px;">
+        <div style="display:flex;align-items:center;gap:8px;padding:6px 0;border-bottom:1px solid var(--fog-ghost);">
+          <div style="width:20px;height:20px;border-radius:50%;background:#0E2830;border:2px solid var(--ora);display:flex;align-items:center;justify-content:center;font:700 7px/1 var(--mono);color:var(--ora);flex-shrink:0;">A</div>
+          <div style="flex:1;"><div style="font:600 10px/1 var(--mono);color:var(--fog);letter-spacing:.03em;">Start</div><div style="font:400 8px/1 var(--mono);color:var(--fog-dim);letter-spacing:.04em;margin-top:2px;">55.8765° N · 3.1920° W</div></div>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;padding:6px 0;border-bottom:1px solid var(--fog-ghost);">
+          <div style="width:20px;height:20px;border-radius:50%;background:#0E2830;border:2px solid var(--ora);display:flex;align-items:center;justify-content:center;font:700 7px/1 var(--mono);color:var(--ora);flex-shrink:0;">B</div>
+          <div style="flex:1;"><div style="font:600 10px/1 var(--mono);color:var(--fog);letter-spacing:.03em;">Summit Approach</div><div style="font:400 8px/1 var(--mono);color:var(--fog-dim);letter-spacing:.04em;margin-top:2px;">442 m · 4.2 km from start</div></div>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;padding:6px 0;border-bottom:1px solid var(--fog-ghost);">
+          <div style="width:20px;height:20px;border-radius:50%;background:#0E2830;border:2px solid var(--ora);display:flex;align-items:center;justify-content:center;font:700 7px/1 var(--mono);color:var(--ora);flex-shrink:0;">C</div>
+          <div style="flex:1;"><div style="font:600 10px/1 var(--mono);color:var(--fog);letter-spacing:.03em;">Ridgeline View</div><div style="font:400 8px/1 var(--mono);color:var(--fog-dim);letter-spacing:.04em;margin-top:2px;">578 m · 8.2 km from start</div></div>
+        </div>
+      </div>
+
+      <!-- Footer — matches PlannerPanel.tsx exactly -->
+      <div style="padding:10px 14px 14px;flex-shrink:0;display:flex;gap:8px;">
+        <button style="flex:1;padding:9px 10px;background:var(--p3);border:1px solid var(--fog-ghost);border-radius:4px;color:var(--fog);font:600 10px/1 var(--mono);letter-spacing:.04em;display:flex;align-items:center;justify-content:center;gap:5px;"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>GPX</button>
+        <button style="flex:1;padding:9px 10px;background:var(--ora);border:none;border-radius:4px;color:var(--p0);font:600 10px/1 var(--mono);letter-spacing:.04em;display:flex;align-items:center;justify-content:center;gap:5px;"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>Image</button>
+      </div>
+    </div>
+
+    <div class="map-area">
+      <div class="map-bg"></div>
+      <div class="heatmap-overlay"></div>
+      <div class="planner-toolbar">
+        <button class="ptb-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 14 4 9l5-5"/><path d="M4 9h10.5a5.5 5.5 0 0 1 0 11H11"/></svg><span>Undo</span></button>
+        <button class="ptb-btn disabled"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14l5-5-5-5"/><path d="M20 9H9.5a5.5 5.5 0 0 0 0 11H13"/></svg><span>Redo</span></button>
+        <div class="ptb-sep"></div>
+        <button class="ptb-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg><span>Clear</span></button>
+        <div class="ptb-sep"></div>
+        <button class="ptb-btn active"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg><span>Snap</span></button>
+        <button class="ptb-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg><span>Import</span></button>
+        <button class="ptb-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg><span>Export</span></button>
+        <button class="ptb-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg><span>Image</span></button>
+        <div class="ptb-spacer"></div>
+        <div class="ptb-route-info">12.4 km · <em>580 m ↑</em></div>
+        <div class="ptb-sep"></div>
+        <button class="ptb-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><line x1="12" y1="2" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="22"/><line x1="2" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="22" y2="12"/></svg><span>Locate</span></button>
+      </div>
+      <svg class="map-svg" viewBox="0 0 900 760" preserveAspectRatio="xMidYMid slice">
+        <polyline points="200,560 240,530 278,502 308,472 332,440 350,408 362,374 368,338 370,302 368,268 362,238 352,210" fill="none" stroke="#E07020" stroke-width="6" stroke-opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>
+        <polyline points="200,560 240,530 278,502 308,472 332,440 350,408 362,374 368,338 370,302 368,268 362,238 352,210" fill="none" stroke="rgba(7,14,20,0.55)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="200" cy="560" r="10" fill="#0E2830" stroke="#E07020" stroke-width="2.5"/>
+        <text x="200" y="560" text-anchor="middle" dominant-baseline="central" fill="#E07020" font-size="8" font-family="IBM Plex Mono" font-weight="700">A</text>
+        <circle cx="368" cy="338" r="8" fill="#0E2830" stroke="#E07020" stroke-width="2"/>
+        <text x="368" y="338" text-anchor="middle" dominant-baseline="central" fill="#E07020" font-size="7" font-family="IBM Plex Mono" font-weight="700">B</text>
+        <circle cx="352" cy="210" r="9" fill="#0E2830" stroke="#E07020" stroke-width="2.5"/>
+        <text x="352" y="210" text-anchor="middle" dominant-baseline="central" fill="#E07020" font-size="8" font-family="IBM Plex Mono" font-weight="700">C</text>
+      </svg>
+      <div class="map-compass"><svg viewBox="0 0 36 36"><circle cx="18" cy="18" r="16" fill="rgba(7,14,20,0.78)" stroke="#1E4858" stroke-width="1"/><polygon points="18,4 21,18 18,15 15,18" fill="#E07020"/><polygon points="18,32 21,18 18,21 15,18" fill="rgba(240,248,250,0.32)"/><text x="18" y="10.5" text-anchor="middle" dominant-baseline="central" fill="#E07020" font-size="5" font-family="IBM Plex Mono" font-weight="700">N</text></svg></div>
+      <div class="layers-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg></div>
+    </div>
+
+  </div></div>
+  <div class="frame-note">Route header replaces the old "Route in Progress" label — name, location, and an autosave chip sit above the unchanged stats card.</div>
+</div><!-- /frame 01 -->
+
+
+<!-- ════════════════════════════════════════
+     FRAME 02 · MY ROUTES FLYOUT OPEN
+════════════════════════════════════════ -->
+<div class="frame-wrap">
+  <div class="frame-label">02 — My Routes · Flyout Open</div>
+  <div class="frame-border"><div class="desk-frame">
+
+    <div class="panel">
+      <div class="status-bar"><span class="status-time">10:15</span><span class="status-sep"></span><div class="status-dot"></div><span class="status-synced">synced</span><div class="status-avatar">PC</div></div>
+      <div class="panel-hdr"><div class="wordmark">plot</div></div>
+      <div class="tab-bar"><div class="tab">Activities</div><div class="tab active">Planner</div></div>
+
+      <div class="route-switcher open">
+        <div class="route-switcher-glyph"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+        <div class="route-switcher-body"><div class="route-switcher-name">Pentland Skyline</div></div>
+        <svg class="ico-sm route-switcher-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+
+        <div class="route-flyout">
+          <div class="route-flyout-hdr">My Routes · 5</div>
+          <div class="route-flyout-list">
+            <div class="route-flyout-item current">
+              <svg class="ico-xs route-item-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              <div class="route-item-glyph"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+              <div class="route-item-info"><div class="route-item-name">Pentland Skyline</div><div class="route-item-meta">12.4 km · Just now</div></div>
+            </div>
+            <div class="route-flyout-item">
+              <div class="route-item-check-ghost"></div>
+              <div class="route-item-glyph"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+              <div class="route-item-info"><div class="route-item-name">Ridgeline Loop</div><div class="route-item-meta">18.7 km · 2d ago</div></div>
+              <button class="route-item-overflow-btn"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+            </div>
+            <div class="route-flyout-item">
+              <div class="route-item-check-ghost"></div>
+              <div class="route-item-glyph"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+              <div class="route-item-info"><div class="route-item-name">Coastal Loop AM</div><div class="route-item-meta">9.2 km · 6d ago</div></div>
+              <button class="route-item-overflow-btn"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+            </div>
+            <div class="route-flyout-item">
+              <div class="route-item-check-ghost"></div>
+              <div class="route-item-glyph"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+              <div class="route-item-info"><div class="route-item-name">Forth Bridge Out-and-Back</div><div class="route-item-meta">24.1 km · 2w ago</div></div>
+              <button class="route-item-overflow-btn"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+            </div>
+            <div class="route-flyout-item">
+              <div class="route-item-check-ghost"></div>
+              <div class="route-item-glyph untitled"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+              <div class="route-item-info"><div class="route-item-name untitled">Untitled route</div><div class="route-item-meta">3.1 km · 4h ago</div></div>
+              <button class="route-item-overflow-btn"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+            </div>
+          </div>
+          <div class="route-flyout-new"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>New route</div>
+        </div>
+      </div>
+
+      <div class="route-identity-sub" style="opacity:0.3;"><div class="route-location">Pentland Hills · Edinburgh</div><div class="autosave-chip"><div class="autosave-dot"></div>Saved</div></div>
+      <div class="route-hud" style="opacity:0.3;">
+        <div class="route-hud-grid">
+          <div class="route-hud-stat"><div class="val">12.4</div><div class="lbl">km</div></div>
+          <div class="route-hud-stat"><div class="val">580</div><div class="lbl">m elev</div></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="map-area">
+      <div class="map-bg"></div>
+      <div class="planner-toolbar">
+        <button class="ptb-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 14 4 9l5-5"/><path d="M4 9h10.5a5.5 5.5 0 0 1 0 11H11"/></svg><span>Undo</span></button>
+        <button class="ptb-btn disabled"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14l5-5-5-5"/><path d="M20 9H9.5a5.5 5.5 0 0 0 0 11H13"/></svg><span>Redo</span></button>
+        <div class="ptb-spacer"></div>
+        <div class="ptb-route-info">12.4 km · <em>580 m ↑</em></div>
+      </div>
+      <svg class="map-svg" viewBox="0 0 900 760" preserveAspectRatio="xMidYMid slice">
+        <polyline points="200,560 240,530 278,502 308,472 332,440 350,408 362,374 368,338 370,302 368,268 362,238 352,210" fill="none" stroke="#E07020" stroke-width="6" stroke-opacity="0.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      <div class="map-compass"><svg viewBox="0 0 36 36"><circle cx="18" cy="18" r="16" fill="rgba(7,14,20,0.78)" stroke="#1E4858" stroke-width="1"/><polygon points="18,4 21,18 18,15 15,18" fill="#E07020"/><polygon points="18,32 21,18 18,21 15,18" fill="rgba(240,248,250,0.32)"/><text x="18" y="10.5" text-anchor="middle" dominant-baseline="central" fill="#E07020" font-size="5" font-family="IBM Plex Mono" font-weight="700">N</text></svg></div>
+    </div>
+
+  </div></div>
+  <div class="frame-note">Compact rows: name + distance + relative last-edited. Checkmark marks the route currently loaded. "Untitled route" reads dimmer to signal it hasn't been named yet.</div>
+</div><!-- /frame 02 -->
+
+
+<!-- ════════════════════════════════════════
+     FRAME 03 · UNTITLED ROUTE (autosave-first)
+════════════════════════════════════════ -->
+<div class="frame-wrap">
+  <div class="frame-label">03 — Untitled Route · Autosaving</div>
+  <div class="frame-border"><div class="desk-frame">
+
+    <div class="panel">
+      <div class="status-bar"><span class="status-time">14:02</span><span class="status-sep"></span><div class="status-dot"></div><span class="status-synced">synced</span><div class="status-avatar">PC</div></div>
+      <div class="panel-hdr"><div class="wordmark">plot</div></div>
+      <div class="tab-bar"><div class="tab">Activities</div><div class="tab active">Planner</div></div>
+
+      <div class="route-switcher">
+        <div class="route-switcher-glyph untitled"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+        <div class="route-switcher-body"><div class="route-switcher-name untitled">Untitled route <svg class="ico-xs" style="display:inline;vertical-align:-1px;margin-left:3px;color:var(--fog-dim);" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg></div></div>
+        <svg class="ico-sm route-switcher-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </div>
+      <div class="route-identity-sub">
+        <div class="route-location">Locating…</div>
+        <div class="autosave-chip"><div class="autosave-dot saving"></div>Saving…</div>
+      </div>
+
+      <div class="route-hud">
+        <div class="route-hud-grid">
+          <div class="route-hud-stat"><div class="val">2.1</div><div class="lbl">km</div></div>
+          <div class="route-hud-stat"><div class="val">40</div><div class="lbl">m elev</div></div>
+          <div class="route-hud-stat"><div class="val">2</div><div class="lbl">waypoints</div></div>
+          <div class="route-hud-stat"><div class="val">~15m</div><div class="lbl">est. time</div></div>
+        </div>
+      </div>
+
+      <div style="padding:4px 14px 4px;flex-shrink:0;"><div class="planner-section-lbl">Waypoints</div></div>
+      <div style="overflow-y:auto;flex:1;padding:0 14px;">
+        <div style="display:flex;align-items:center;gap:8px;padding:6px 0;border-bottom:1px solid var(--fog-ghost);">
+          <div style="width:20px;height:20px;border-radius:50%;background:#0E2830;border:2px solid var(--ora);display:flex;align-items:center;justify-content:center;font:700 7px/1 var(--mono);color:var(--ora);flex-shrink:0;">A</div>
+          <div style="flex:1;"><div style="font:600 10px/1 var(--mono);color:var(--fog);letter-spacing:.03em;">Start</div><div style="font:400 8px/1 var(--mono);color:var(--fog-dim);letter-spacing:.04em;margin-top:2px;">55.9210° N · 3.1740° W</div></div>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;padding:6px 0;border-bottom:1px solid var(--fog-ghost);background:rgba(224,112,32,0.05);border-radius:3px;">
+          <div style="width:20px;height:20px;border-radius:50%;background:#0E2830;border:2px solid var(--ora);display:flex;align-items:center;justify-content:center;font:700 7px/1 var(--mono);color:var(--ora);flex-shrink:0;">B</div>
+          <div style="flex:1;"><div style="font:600 10px/1 var(--mono);color:var(--ice);letter-spacing:.03em;">Waypoint 2</div><div style="font:400 8px/1 var(--mono);color:var(--fog-dim);letter-spacing:.04em;margin-top:2px;">2.1 km from start · <span style="color:var(--ora)">selected</span></div></div>
+        </div>
+      </div>
+
+      <div style="padding:10px 14px 14px;flex-shrink:0;display:flex;gap:8px;">
+        <button style="flex:1;padding:9px 10px;background:var(--p3);border:1px solid var(--fog-ghost);border-radius:4px;color:var(--fog);font:600 10px/1 var(--mono);letter-spacing:.04em;display:flex;align-items:center;justify-content:center;gap:5px;"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>GPX</button>
+        <button style="flex:1;padding:9px 10px;background:var(--ora);border:none;border-radius:4px;color:var(--p0);font:600 10px/1 var(--mono);letter-spacing:.04em;display:flex;align-items:center;justify-content:center;gap:5px;"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>Image</button>
+      </div>
+    </div>
+
+    <div class="map-area">
+      <div class="map-bg"></div>
+      <div class="planner-toolbar">
+        <button class="ptb-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 14 4 9l5-5"/><path d="M4 9h10.5a5.5 5.5 0 0 1 0 11H11"/></svg><span>Undo</span></button>
+        <button class="ptb-btn disabled"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14l5-5-5-5"/><path d="M20 9H9.5a5.5 5.5 0 0 0 0 11H13"/></svg><span>Redo</span></button>
+        <div class="ptb-sep"></div>
+        <button class="ptb-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg><span>Clear</span></button>
+        <div class="ptb-sep"></div>
+        <button class="ptb-btn active"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg><span>Snap</span></button>
+        <div class="ptb-spacer"></div>
+        <div class="ptb-route-info">2.1 km · <em>40 m ↑</em></div>
+      </div>
+      <svg class="map-svg" viewBox="0 0 900 760" preserveAspectRatio="xMidYMid slice">
+        <polyline points="420,540 460,470" fill="none" stroke="#E07020" stroke-width="6" stroke-opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>
+        <polyline points="420,540 460,470" fill="none" stroke="rgba(7,14,20,0.55)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="420" cy="540" r="10" fill="#0E2830" stroke="#E07020" stroke-width="2.5"/>
+        <text x="420" y="540" text-anchor="middle" dominant-baseline="central" fill="#E07020" font-size="8" font-family="IBM Plex Mono" font-weight="700">A</text>
+        <circle cx="460" cy="470" r="16" fill="rgba(224,112,32,0.10)" stroke="#E07020" stroke-width="1" stroke-dasharray="3 2"/>
+        <circle cx="460" cy="470" r="9" fill="#0E2830" stroke="#E07020" stroke-width="2.5"/>
+        <text x="460" y="470" text-anchor="middle" dominant-baseline="central" fill="#E07020" font-size="8" font-family="IBM Plex Mono" font-weight="700">B</text>
+      </svg>
+      <div class="map-compass"><svg viewBox="0 0 36 36"><circle cx="18" cy="18" r="16" fill="rgba(7,14,20,0.78)" stroke="#1E4858" stroke-width="1"/><polygon points="18,4 21,18 18,15 15,18" fill="#E07020"/><polygon points="18,32 21,18 18,21 15,18" fill="rgba(240,248,250,0.32)"/><text x="18" y="10.5" text-anchor="middle" dominant-baseline="central" fill="#E07020" font-size="5" font-family="IBM Plex Mono" font-weight="700">N</text></svg></div>
+    </div>
+
+  </div></div>
+  <div class="frame-note">First waypoint silently creates "Untitled route" and it's already in the library — no save dialog, no interruption. The dim pulsing dot + "Saving…" confirms writes are happening; it settles to solid green "Saved" ~1s after the last edit.</div>
+</div><!-- /frame 03 -->
+
+
+<!-- ════════════════════════════════════════
+     FRAME 04 · INLINE RENAME
+════════════════════════════════════════ -->
+<div class="frame-wrap">
+  <div class="frame-label">04 — Inline Rename</div>
+  <div class="frame-border"><div class="desk-frame">
+
+    <div class="panel">
+      <div class="status-bar"><span class="status-time">10:16</span><span class="status-sep"></span><div class="status-dot"></div><span class="status-synced">synced</span><div class="status-avatar">PC</div></div>
+      <div class="panel-hdr"><div class="wordmark">plot</div></div>
+      <div class="tab-bar"><div class="tab">Activities</div><div class="tab active">Planner</div></div>
+
+      <div class="route-switcher">
+        <div class="route-switcher-glyph"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+        <input class="route-name-input" value="Pentland Skyline" style="background:rgba(224,112,32,0.12);">
+      </div>
+      <div class="rename-hint">Enter to save · Esc to cancel</div>
+
+      <div class="route-identity-sub" style="margin-top:6px;"><div class="route-location">Pentland Hills · Edinburgh</div><div class="autosave-chip"><div class="autosave-dot"></div>Saved</div></div>
+
+      <div class="route-hud">
+        <div class="route-hud-grid">
+          <div class="route-hud-stat"><div class="val">12.4</div><div class="lbl">km</div></div>
+          <div class="route-hud-stat"><div class="val">580</div><div class="lbl">m elev</div></div>
+          <div class="route-hud-stat"><div class="val">3</div><div class="lbl">waypoints</div></div>
+          <div class="route-hud-stat"><div class="val">~4h</div><div class="lbl">est. time</div></div>
+        </div>
+      </div>
+      <div style="flex:1;"></div>
+      <div style="padding:10px 14px 14px;flex-shrink:0;display:flex;gap:8px;">
+        <button style="flex:1;padding:9px 10px;background:var(--p3);border:1px solid var(--fog-ghost);border-radius:4px;color:var(--fog);font:600 10px/1 var(--mono);letter-spacing:.04em;">GPX</button>
+        <button style="flex:1;padding:9px 10px;background:var(--ora);border:none;border-radius:4px;color:var(--p0);font:600 10px/1 var(--mono);letter-spacing:.04em;">Image</button>
+      </div>
+    </div>
+
+    <div class="map-area">
+      <div class="map-bg"></div>
+      <div class="planner-toolbar">
+        <div class="ptb-hint">Renaming route…</div>
+        <div class="ptb-spacer"></div>
+        <div class="ptb-route-info">12.4 km · <em>580 m ↑</em></div>
+      </div>
+      <svg class="map-svg" viewBox="0 0 900 760" preserveAspectRatio="xMidYMid slice">
+        <polyline points="200,560 240,530 278,502 308,472 332,440 350,408 362,374 368,338 370,302 368,268 362,238 352,210" fill="none" stroke="#E07020" stroke-width="6" stroke-opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>
+        <polyline points="200,560 240,530 278,502 308,472 332,440 350,408 362,374 368,338 370,302 368,268 362,238 352,210" fill="none" stroke="rgba(7,14,20,0.55)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      <div class="map-compass"><svg viewBox="0 0 36 36"><circle cx="18" cy="18" r="16" fill="rgba(7,14,20,0.78)" stroke="#1E4858" stroke-width="1"/><polygon points="18,4 21,18 18,15 15,18" fill="#E07020"/><polygon points="18,32 21,18 18,21 15,18" fill="rgba(240,248,250,0.32)"/><text x="18" y="10.5" text-anchor="middle" dominant-baseline="central" fill="#E07020" font-size="5" font-family="IBM Plex Mono" font-weight="700">N</text></svg></div>
+    </div>
+
+  </div></div>
+  <div class="frame-note">Click the name (or its pencil icon in the untitled state) to rename in place — no modal. Selection is pre-highlighted so typing replaces immediately, matching the Docs-style "type to overwrite" pattern.</div>
+</div><!-- /frame 04 -->
+
+
+<!-- ════════════════════════════════════════
+     FRAME 05 · OVERFLOW MENU + DELETE CONFIRM
+════════════════════════════════════════ -->
+<div class="frame-wrap">
+  <div class="frame-label">05 — Route Overflow · Delete Confirm</div>
+  <div class="frame-border"><div class="desk-frame">
+
+    <div class="panel">
+      <div class="status-bar"><span class="status-time">10:17</span><span class="status-sep"></span><div class="status-dot"></div><span class="status-synced">synced</span><div class="status-avatar">PC</div></div>
+      <div class="panel-hdr"><div class="wordmark">plot</div></div>
+      <div class="tab-bar"><div class="tab">Activities</div><div class="tab active">Planner</div></div>
+
+      <div class="route-switcher open">
+        <div class="route-switcher-glyph"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+        <div class="route-switcher-body"><div class="route-switcher-name">Pentland Skyline</div></div>
+        <svg class="ico-sm route-switcher-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+
+        <div class="route-flyout">
+          <div class="route-flyout-hdr">My Routes · 5</div>
+          <div class="route-flyout-list">
+            <div class="route-flyout-item current">
+              <svg class="ico-xs route-item-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              <div class="route-item-glyph"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+              <div class="route-item-info"><div class="route-item-name">Pentland Skyline</div><div class="route-item-meta">12.4 km · Just now</div></div>
+            </div>
+            <div class="route-flyout-item" style="background:var(--p2);">
+              <div class="route-item-check-ghost"></div>
+              <div class="route-item-glyph"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+              <div class="route-item-info"><div class="route-item-name">Coastal Loop AM</div><div class="route-item-meta">9.2 km · 6d ago</div></div>
+              <button class="route-item-overflow-btn" style="background:var(--p3);color:var(--fog);"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+            </div>
+            <div class="route-flyout-item">
+              <div class="route-item-check-ghost"></div>
+              <div class="route-item-glyph"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+              <div class="route-item-info"><div class="route-item-name">Forth Bridge Out-and-Back</div><div class="route-item-meta">24.1 km · 2w ago</div></div>
+            </div>
+          </div>
+          <div class="route-flyout-new"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>New route</div>
+        </div>
+      </div>
+
+      <!-- Context menu + delete confirm render as panel-level siblings (not
+           nested in the scrollable/overflow-hidden flyout) so they aren't
+           clipped. Positioned to land visually beside the "Coastal Loop AM"
+           row's overflow button. -->
+      <div class="ctx-menu" style="top:270px;left:154px;">
+        <div class="ctx-menu-item"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>Rename</div>
+        <div class="ctx-menu-item"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>Duplicate</div>
+        <div class="ctx-menu-sep"></div>
+        <div class="ctx-menu-item danger"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>Delete</div>
+      </div>
+
+      <!-- Storyboard inset: what "Delete" leads to — rendered over the map,
+           just past the panel's right edge, with room to breathe. -->
+      <div class="storyboard-caption" style="top:242px;left:316px;"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>tapping Delete shows</div>
+      <div class="confirm-card" style="top:262px;left:316px;">
+        <div class="confirm-card-title">Delete <strong>"Coastal Loop AM"</strong>? This can't be undone.</div>
+        <div class="confirm-card-actions">
+          <button class="confirm-btn cancel">Cancel</button>
+          <button class="confirm-btn delete">Delete</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="map-area">
+      <div class="map-bg"></div>
+    </div>
+
+  </div></div>
+  <div class="frame-note">Each row's overflow opens Rename / Duplicate / Delete. Delete always routes through an explicit confirm (shown inset here) — never a silent destructive action.</div>
+</div><!-- /frame 05 -->
+
+
+<!-- ════════════════════════════════════════
+     FRAME 06 · EMPTY LIBRARY (first-time premium)
+════════════════════════════════════════ -->
+<div class="frame-wrap">
+  <div class="frame-label">06 — Empty Library</div>
+  <div class="frame-border"><div class="desk-frame">
+
+    <div class="panel">
+      <div class="status-bar"><span class="status-time">09:51</span><span class="status-sep"></span><div class="status-dot"></div><span class="status-synced">synced</span><div class="status-avatar">PC</div></div>
+      <div class="panel-hdr"><div class="wordmark">plot</div></div>
+      <div class="tab-bar"><div class="tab">Activities</div><div class="tab active">Planner</div></div>
+
+      <div class="route-switcher open">
+        <div class="route-switcher-glyph untitled"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+        <div class="route-switcher-body"><div class="route-switcher-label">My Routes</div></div>
+        <svg class="ico-sm route-switcher-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+
+        <div class="route-flyout">
+          <div class="route-flyout-empty">
+            <div class="route-flyout-empty-icon"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+            <div class="route-flyout-empty-title">No saved routes yet</div>
+            <div class="route-flyout-empty-sub">Start plotting to create one — it saves itself.</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Base start state — unchanged from existing planner -->
+      <div class="planner-new-route-wrap">
+        <div class="planner-section-lbl" style="opacity:0.4;">New Route</div>
+        <button class="planner-new-btn" style="opacity:0.4;">
+          <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          Start New Route
+        </button>
+        <p style="font:400 9px/1.5 var(--mono);color:var(--fog-dim);letter-spacing:.04em;margin-top:8px;text-align:center;opacity:0.4;">or click anywhere on the map</p>
+      </div>
+      <div style="padding:8px 14px 0;opacity:0.4;">
+        <button class="detail-btn-secondary" style="width:100%;">
+          <svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+          Import GPX
+        </button>
+      </div>
+    </div>
+
+    <div class="map-area">
+      <div class="map-bg"></div>
+      <div class="planner-toolbar">
+        <button class="ptb-btn disabled"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 14 4 9l5-5"/><path d="M4 9h10.5a5.5 5.5 0 0 1 0 11H11"/></svg><span>Undo</span></button>
+        <button class="ptb-btn disabled"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14l5-5-5-5"/><path d="M20 9H9.5a5.5 5.5 0 0 0 0 11H13"/></svg><span>Redo</span></button>
+        <div class="ptb-spacer"></div>
+        <div class="ptb-hint">Click the map to place your first point</div>
+      </div>
+    </div>
+
+  </div></div>
+  <div class="frame-note">First-time premium users see this the moment they open My Routes. The library and the "Start New Route" CTA lead to the same place — placing a point creates the first entry automatically.</div>
+</div><!-- /frame 06 -->
+
+</div><!-- /frames-row -->
+
+</body>
+</html>

--- a/mockup-saved-routes-mobile.html
+++ b/mockup-saved-routes-mobile.html
@@ -1,0 +1,424 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>plot — mockup — saved routes — mobile</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Ribeye+Marrow&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --p0: #070E14;
+      --p1: #0E2830;
+      --p2: #163840;
+      --p3: #1E4858;
+      --p4: #2A5860;
+      --ora: #E07020;
+      --grn: #40B060;
+      --blu: #4080C0;
+      --ice: #F0F8FA;
+      --fog: rgba(240,248,250,0.72);
+      --fog-dim: rgba(240,248,250,0.45);
+      --fog-ghost: rgba(240,248,250,0.08);
+      --glass-lgt: rgba(7,14,20,0.58);
+      --glass:     rgba(7,14,20,0.82);
+      --glass-hvy: rgba(7,14,20,0.94);
+      --mono: 'IBM Plex Mono', monospace;
+      --display: 'Ribeye Marrow', cursive;
+    }
+
+    body { background: #040A0F; color: var(--ice); font-family: var(--mono); min-height: 100vh; }
+
+    /* PAGE CHROME */
+    .page-header { padding: 48px 56px 32px; border-bottom: 1px solid var(--fog-ghost); display: flex; align-items: baseline; gap: 24px; }
+    .page-wordmark { font-family: var(--display); font-size: 28px; color: var(--ice); letter-spacing: .02em; }
+    .page-title { font: 600 11px/1 var(--mono); letter-spacing: .16em; text-transform: uppercase; color: var(--fog-dim); }
+    .page-tag { margin-left: auto; font: 400 10px/1 var(--mono); color: var(--p4); letter-spacing: .1em; }
+    .section-header { padding: 40px 56px 20px; }
+    .section-label { font: 600 10px/1 var(--mono); letter-spacing: .2em; text-transform: uppercase; color: var(--ora); margin-bottom: 6px; }
+    .section-desc { font: 400 12px/1.5 var(--mono); color: var(--fog-dim); max-width: 640px; }
+    .frames-row { display: flex; gap: 32px; padding: 0 56px 56px; overflow-x: auto; align-items: flex-start; }
+    .frame-wrap { flex-shrink: 0; width: 390px; }
+    .frame-label { font: 600 9px/1 var(--mono); letter-spacing: .18em; text-transform: uppercase; color: var(--fog-dim); margin-bottom: 10px; }
+    .frame-note { font: 400 9px/1.5 var(--mono); color: var(--p4); letter-spacing: .02em; margin-top: 10px; }
+    .frame-border { border: 1px solid var(--p3); border-radius: 4px; overflow: hidden; }
+
+    /* Note: mobile chrome below is copied 1:1 from the real components —
+       MobileHeader.tsx (floating pill capsule), PlannerToolbar.tsx (floating
+       toolbar pill), and the planner HUD block in MapShell.tsx (floating card).
+       This is NOT mockup-h.html's mobile design — that mockup predates a
+       rebuild to this floating-capsule language and is out of date. */
+
+    .mob-frame { width: 390px; height: 844px; position: relative; overflow: hidden; background: var(--p0); }
+    .mob-map { position: absolute; inset: 0; background-image: url('osmapdark.jpg'); background-size: cover; background-position: center; }
+
+    /* Header capsule — MobileHeader.tsx */
+    .mob-header { position: absolute; top: 10px; left: 10px; right: 10px; height: 48px; background: var(--glass-hvy); backdrop-filter: blur(16px); border: 1px solid var(--p3); border-radius: 999px; box-shadow: 0 2px 12px rgba(0,0,0,.22); display: flex; align-items: center; padding: 0 14px 0 16px; z-index: 30; }
+    .mob-header-word { font-family: var(--display); font-size: 20px; color: var(--ice); line-height: 1; flex-shrink: 0; margin-right: 2px; }
+    .mob-header-sep { width: 1px; height: 22px; background: var(--p3); margin: 0 12px; flex-shrink: 0; }
+    .mob-tabs { position: relative; display: flex; gap: 3px; align-items: center; flex: 1; }
+    .mob-tab-indicator { position: absolute; top: 0; height: 100%; width: 75px; background: var(--ora); border-radius: 999px; }
+    .mob-tab { width: 75px; height: 26px; border-radius: 999px; background: transparent; border: none; font: 600 8px/1 var(--mono); letter-spacing: .11em; text-transform: uppercase; cursor: pointer; position: relative; z-index: 1; }
+    .mob-tab.active { color: #fff; }
+    .mob-tab:not(.active) { color: var(--fog-dim); }
+    .mob-avatar { width: 28px; height: 28px; border-radius: 50%; background: var(--ora); display: flex; align-items: center; justify-content: center; font-size: 10px; font-weight: 700; color: #fff; flex-shrink: 0; }
+
+    /* Toolbar pill — PlannerToolbar.tsx mobile */
+    .mob-toolbar { position: absolute; top: 68px; left: 10px; right: 10px; height: 46px; border-radius: 10px; border: 1px solid var(--p3); z-index: 20; display: flex; align-items: center; padding: 0 12px; gap: 2px; background: var(--glass-lgt); backdrop-filter: blur(16px); }
+    .mob-tb-btn { flex: 1; height: 36px; border-radius: 3px; background: transparent; border: none; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 2px; color: var(--fog); }
+    .mob-tb-btn.active { color: var(--ora); }
+    .mob-tb-btn.disabled { opacity: .28; }
+    .mob-tb-btn span { font: 600 9px/1 var(--mono); letter-spacing: .06em; text-transform: uppercase; color: inherit; }
+
+    /* Circular floating buttons — Compass / LayersPanel trigger */
+    .mob-circle-btn { position: absolute; width: 44px; height: 44px; border-radius: 50%; background: var(--glass-hvy); backdrop-filter: blur(12px); border: 1px solid var(--p3); display: flex; align-items: center; justify-content: center; color: var(--fog-dim); box-shadow: 0 2px 8px rgba(0,0,0,.3); z-index: 14; }
+
+    /* Planner HUD — floating card, MapShell.tsx */
+    .mob-hud { position: absolute; bottom: 10px; left: 10px; right: 10px; background: var(--p1); border: 1px solid var(--p3); border-radius: 16px; box-shadow: 0 -4px 24px rgba(0,0,0,.35); z-index: 20; display: flex; flex-direction: column; overflow: hidden; }
+    .mob-hud-handle-zone { flex-shrink: 0; padding: 10px 0 0; }
+    .mob-hud-handle { width: 48px; height: 6px; background: var(--p3); border-radius: 3px; margin: 0 auto; }
+
+    /* NEW: route identity — sits between the handle and the stats row */
+    .mob-hud-route { display: flex; align-items: center; gap: 8px; padding: 10px 16px 8px; cursor: pointer; }
+    .mob-hud-route-glyph { width: 20px; height: 20px; border-radius: 4px; background: var(--p2); border: 1px solid var(--p3); display: flex; align-items: center; justify-content: center; color: var(--ora); flex-shrink: 0; }
+    .mob-hud-route-body { flex: 1; min-width: 0; }
+    .mob-hud-route-name { font: 700 12px/1.3 var(--mono); color: var(--ice); letter-spacing: .02em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .mob-hud-route-name.untitled { color: var(--fog-dim); }
+    .mob-hud-route-sub { display: flex; align-items: center; justify-content: space-between; margin-top: 3px; gap: 8px; }
+    .mob-hud-route-loc { font: 400 9px/1 var(--mono); color: var(--fog-dim); letter-spacing: .03em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .mob-hud-route-chevron { color: var(--fog-dim); flex-shrink: 0; }
+
+    .autosave-chip { display: flex; align-items: center; gap: 5px; font: 500 8px/1 var(--mono); letter-spacing: .08em; text-transform: uppercase; color: var(--fog-dim); flex-shrink: 0; }
+    .autosave-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--grn); box-shadow: 0 0 4px var(--grn); flex-shrink: 0; }
+    .autosave-dot.saving { background: var(--fog-dim); box-shadow: none; animation: pulse-dot 1s ease-in-out infinite; }
+    @keyframes pulse-dot { 0%, 100% { opacity: 1; } 50% { opacity: .25; } }
+
+    .mob-hud-divider { height: 1px; background: var(--fog-ghost); margin: 0 16px; }
+    .mob-hud-stats { display: flex; padding: 10px 20px 14px; }
+    .mob-hud-stat { flex: 1; display: flex; flex-direction: column; gap: 3px; border-right: 1px solid var(--fog-ghost); padding-right: 16px; }
+    .mob-hud-stat:not(:first-child) { padding-left: 16px; }
+    .mob-hud-stat:last-child { border-right: none; }
+    .mob-hud-val { font: 700 18px/1 var(--mono); color: var(--ora); }
+    .mob-hud-lbl { font: 400 8px/1 var(--mono); letter-spacing: .1em; text-transform: uppercase; color: var(--fog-dim); }
+    .mob-hud-actions { display: flex; gap: 10px; padding: 0 16px 16px; }
+    .mob-hud-btn { flex: 1; height: 40px; border-radius: 4px; border: none; font: 700 10px/1 var(--mono); letter-spacing: .1em; text-transform: uppercase; display: flex; align-items: center; justify-content: center; gap: 6px; }
+    .mob-hud-btn.neutral { background: var(--p3); color: var(--fog); }
+    .mob-hud-btn.primary { background: var(--ora); color: var(--p0); }
+    .mob-hud-btn.disabled { background: var(--p3); color: var(--fog-dim); }
+
+    /* Inline rename — replaces the name line */
+    .mob-route-name-input { flex: 1; min-width: 0; background: transparent; border: none; border-bottom: 1px solid var(--ora); outline: none; font: 700 12px/1.3 var(--mono); color: var(--ice); letter-spacing: .02em; padding: 0 0 2px; }
+    .mob-rename-confirm { width: 22px; height: 22px; border-radius: 50%; background: var(--ora); border: none; display: flex; align-items: center; justify-content: center; color: var(--p0); flex-shrink: 0; }
+
+    /* My Routes sheet — floating card, tall */
+    .mob-routes-sheet { position: absolute; bottom: 10px; left: 10px; right: 10px; height: 610px; background: var(--p1); border: 1px solid var(--p3); border-radius: 16px; box-shadow: 0 -4px 24px rgba(0,0,0,.4); z-index: 40; display: flex; flex-direction: column; overflow: hidden; }
+    .mob-routes-hdr { display: flex; align-items: center; gap: 8px; padding: 14px 16px 12px; flex-shrink: 0; border-bottom: 1px solid var(--fog-ghost); }
+    .mob-routes-title { font: 700 13px/1 var(--mono); color: var(--ice); letter-spacing: .06em; flex: 1; }
+    .mob-routes-count { font: 400 10px/1 var(--mono); color: var(--fog-dim); }
+    .mob-routes-close { width: 28px; height: 28px; border-radius: 4px; border: 1px solid var(--p3); background: transparent; display: flex; align-items: center; justify-content: center; color: var(--fog-dim); flex-shrink: 0; }
+    .mob-routes-list { flex: 1; overflow-y: auto; }
+    .mob-route-item { display: flex; align-items: center; gap: 12px; padding: 12px 16px; border-bottom: 1px solid var(--fog-ghost); }
+    .mob-route-item.current { background: rgba(224,112,32,0.06); }
+    .route-item-glyph { width: 30px; height: 30px; border-radius: 6px; background: var(--p2); border: 1px solid var(--p3); display: flex; align-items: center; justify-content: center; color: var(--ora); flex-shrink: 0; }
+    .route-item-glyph.untitled { color: var(--fog-dim); }
+    .mob-route-item-info { flex: 1; min-width: 0; }
+    .mob-route-item-name { font: 600 12px/1.3 var(--mono); color: var(--ice); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .mob-route-item-name.untitled { color: var(--fog-dim); }
+    .mob-route-item-meta { font: 400 9px/1 var(--mono); color: var(--fog-dim); margin-top: 4px; letter-spacing: .03em; }
+    .mob-route-item-check { width: 15px; height: 15px; color: var(--ora); flex-shrink: 0; }
+    .mob-route-item-overflow { width: 30px; height: 30px; border-radius: 4px; background: transparent; border: none; display: flex; align-items: center; justify-content: center; color: var(--fog-dim); flex-shrink: 0; }
+    .mob-routes-new { display: flex; align-items: center; justify-content: center; gap: 8px; height: 52px; flex-shrink: 0; border-top: 1px solid var(--fog-ghost); color: var(--ora); font: 700 10px/1 var(--mono); letter-spacing: .1em; text-transform: uppercase; }
+
+    /* Route actions sheet — compact */
+    .mob-actions-sheet { position: absolute; bottom: 10px; left: 10px; right: 10px; background: var(--p1); border: 1px solid var(--p3); border-radius: 16px; box-shadow: 0 -4px 24px rgba(0,0,0,.4); z-index: 40; overflow: hidden; }
+    .mob-actions-hdr { padding: 14px 16px 10px; border-bottom: 1px solid var(--fog-ghost); }
+    .mob-actions-hdr-lbl { font: 500 8px/1 var(--mono); letter-spacing: .12em; text-transform: uppercase; color: var(--fog-dim); margin-bottom: 4px; }
+    .mob-actions-hdr-name { font: 700 13px/1.3 var(--mono); color: var(--ice); }
+    .mob-action-row { display: flex; align-items: center; gap: 12px; padding: 14px 16px; }
+    .mob-action-row.danger { color: rgba(220,80,80,0.9); }
+    .mob-action-row:not(.danger) { color: var(--fog); }
+    .mob-action-row span { font: 600 11px/1 var(--mono); letter-spacing: .04em; }
+
+    .storyboard-caption { font: 500 8px/1 var(--mono); letter-spacing: .08em; text-transform: uppercase; color: var(--p4); display: flex; align-items: center; gap: 4px; margin: 10px 0 8px 16px; }
+    .confirm-card-inline { margin: 0 16px 14px; background: var(--p2); border: 1px solid rgba(200,60,60,0.35); border-radius: 8px; padding: 12px; }
+    .confirm-card-title { font: 500 10.5px/1.5 var(--mono); color: var(--fog); letter-spacing: .02em; margin-bottom: 10px; }
+    .confirm-card-title strong { color: var(--ice); font-weight: 600; }
+    .confirm-card-actions { display: flex; gap: 8px; }
+    .confirm-btn { flex: 1; height: 32px; border-radius: 4px; font: 600 9px/1 var(--mono); letter-spacing: .06em; text-transform: uppercase; display: flex; align-items: center; justify-content: center; }
+    .confirm-btn.cancel { background: transparent; border: 1px solid var(--p3); color: var(--fog-dim); }
+    .confirm-btn.delete { background: rgba(200,60,60,0.85); border: none; color: var(--ice); }
+
+    .scrim { position: absolute; inset: 0; background: rgba(4,8,12,0.55); z-index: 35; }
+
+    .ico    { width: 16px; height: 16px; display: block; flex-shrink: 0; }
+    .ico-sm { width: 14px; height: 14px; display: block; flex-shrink: 0; }
+    .ico-xs { width: 12px; height: 12px; display: block; flex-shrink: 0; }
+  </style>
+</head>
+<body>
+
+<div class="page-header">
+  <div class="page-wordmark">plot</div>
+  <div class="page-title">Mockup — Saved Routes · Mobile Flows</div>
+  <div class="page-tag">Premium · 2026</div>
+</div>
+
+<div class="section-header">
+  <div class="section-label">Mobile</div>
+  <div class="section-desc">Chrome below (header pill, toolbar pill, planner HUD card) is copied 1:1 from the shipped components (MobileHeader.tsx, PlannerToolbar.tsx, the HUD block in MapShell.tsx) — floating capsules over a full-bleed map, not the edge-to-edge sheets mockup-h.html showed. The route identity row is a new addition inserted into the HUD, between the drag handle and the stats row.</div>
+</div>
+
+<div class="frames-row">
+
+<!-- ════════════════════════════════════════
+     FRAME 01 · PLANNER HUD WITH ROUTE IDENTITY
+════════════════════════════════════════ -->
+<div class="frame-wrap">
+  <div class="frame-label">01 — Planner HUD · Route Identity</div>
+  <div class="frame-border"><div class="mob-frame">
+
+    <div class="mob-map">
+      <svg style="position:absolute;inset:0;width:100%;height:100%;" viewBox="0 0 390 844" preserveAspectRatio="xMidYMid slice">
+        <polyline points="118,620 140,590 165,558 188,524 208,490 222,454 230,416 234,378 232,340 226,304" fill="none" stroke="#E07020" stroke-width="6" stroke-opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>
+        <polyline points="118,620 140,590 165,558 188,524 208,490 222,454 230,416 234,378 232,340 226,304" fill="none" stroke="rgba(7,14,20,0.55)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="118" cy="620" r="10" fill="#0E2830" stroke="#E07020" stroke-width="2.5"/>
+        <text x="118" y="620" text-anchor="middle" dominant-baseline="central" fill="#E07020" font-size="8" font-family="IBM Plex Mono" font-weight="700">A</text>
+        <circle cx="230" cy="416" r="8" fill="#0E2830" stroke="#E07020" stroke-width="2"/>
+        <text x="230" y="416" text-anchor="middle" dominant-baseline="central" fill="#E07020" font-size="7" font-family="IBM Plex Mono" font-weight="700">B</text>
+        <circle cx="226" cy="304" r="9" fill="#0E2830" stroke="#E07020" stroke-width="2.5"/>
+        <text x="226" y="304" text-anchor="middle" dominant-baseline="central" fill="#E07020" font-size="8" font-family="IBM Plex Mono" font-weight="700">C</text>
+      </svg>
+    </div>
+
+    <div class="mob-header">
+      <div class="mob-header-word">plot</div>
+      <div class="mob-header-sep"></div>
+      <div class="mob-tabs">
+        <div class="mob-tab-indicator" style="left:78px;"></div>
+        <button class="mob-tab">Activities</button>
+        <button class="mob-tab active" style="left:78px;">Planner</button>
+      </div>
+      <div class="mob-header-sep"></div>
+      <div class="mob-avatar">PC</div>
+    </div>
+
+    <div class="mob-toolbar">
+      <button class="mob-tb-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 14 4 9l5-5"/><path d="M4 9h10.5a5.5 5.5 0 0 1 0 11H11"/></svg><span>Undo</span></button>
+      <button class="mob-tb-btn disabled"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14l5-5-5-5"/><path d="M20 9H9.5a5.5 5.5 0 0 0 0 11H13"/></svg><span>Redo</span></button>
+      <button class="mob-tb-btn active"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg><span>Add</span></button>
+      <button class="mob-tb-btn active"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg><span>Snap</span></button>
+      <button class="mob-tb-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg><span>Clear</span></button>
+      <button class="mob-tb-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3L21 7L17 11"/><path d="M3 7h18"/><path d="M7 21L3 17L7 13"/><path d="M21 17H3"/></svg><span>Rev.</span></button>
+    </div>
+
+    <div class="mob-circle-btn" style="top:126px;right:16px;"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg></div>
+    <div class="mob-circle-btn" style="bottom:201px;left:12px;"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3"/></svg></div>
+
+    <!-- Planner HUD -->
+    <div class="mob-hud" style="height:262px;">
+      <div class="mob-hud-handle-zone"><div class="mob-hud-handle"></div></div>
+
+      <div class="mob-hud-route">
+        <div class="mob-hud-route-glyph"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+        <div class="mob-hud-route-body">
+          <div class="mob-hud-route-name">Pentland Skyline</div>
+          <div class="mob-hud-route-sub">
+            <div class="mob-hud-route-loc">Pentland Hills · Edinburgh</div>
+            <div class="autosave-chip"><div class="autosave-dot"></div>Saved</div>
+          </div>
+        </div>
+        <svg class="ico-sm mob-hud-route-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+      </div>
+      <div class="mob-hud-divider"></div>
+
+      <div class="mob-hud-stats">
+        <div class="mob-hud-stat"><div class="mob-hud-val">8.6</div><div class="mob-hud-lbl">km</div></div>
+        <div class="mob-hud-stat"><div class="mob-hud-val">380</div><div class="mob-hud-lbl">m elev</div></div>
+        <div class="mob-hud-stat"><div class="mob-hud-val">3</div><div class="mob-hud-lbl">waypts</div></div>
+      </div>
+      <div style="position:relative;padding:0 16px 10px;">
+        <svg width="100%" height="34" viewBox="0 0 358 34" preserveAspectRatio="none">
+          <defs><linearGradient id="ev1" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#E07020" stop-opacity="0.30"/><stop offset="100%" stop-color="#E07020" stop-opacity="0.02"/></linearGradient></defs>
+          <path d="M0,34 L0,28 C24,26 42,22 62,15 C82,8 96,5 120,4 C144,3 158,9 178,16 C196,22 212,25 234,24 C256,23 276,18 300,12 C320,7 340,8 358,10 L358,34 Z" fill="url(#ev1)"/>
+          <path d="M0,28 C24,26 42,22 62,15 C82,8 96,5 120,4 C144,3 158,9 178,16 C196,22 212,25 234,24 C256,23 276,18 300,12 C320,7 340,8 358,10" fill="none" stroke="#E07020" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+      <div class="mob-hud-actions">
+        <button class="mob-hud-btn neutral"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>Import</button>
+        <button class="mob-hud-btn neutral"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>Image</button>
+        <button class="mob-hud-btn primary"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>Export</button>
+      </div>
+    </div>
+
+  </div></div>
+  <div class="frame-note">The identity row sits above the existing stats row inside the same floating HUD card — no extra chrome added to the screen. Tapping it (or its chevron) opens the My Routes sheet. Collapsing the HUD keeps this row visible; only stats/elevation/actions hide.</div>
+</div><!-- /frame 01 -->
+
+
+<!-- ════════════════════════════════════════
+     FRAME 02 · MY ROUTES SHEET
+════════════════════════════════════════ -->
+<div class="frame-wrap">
+  <div class="frame-label">02 — My Routes Sheet</div>
+  <div class="frame-border"><div class="mob-frame">
+
+    <div class="mob-map" style="opacity:0.5;"></div>
+    <div class="scrim"></div>
+
+    <div class="mob-header" style="opacity:0.4;">
+      <div class="mob-header-word">plot</div>
+      <div class="mob-header-sep"></div>
+      <div class="mob-tabs"><div class="mob-tab-indicator" style="left:78px;"></div><button class="mob-tab">Activities</button><button class="mob-tab active" style="left:78px;">Planner</button></div>
+      <div class="mob-header-sep"></div>
+      <div class="mob-avatar">PC</div>
+    </div>
+
+    <div class="mob-routes-sheet">
+      <div class="mob-routes-hdr">
+        <div class="mob-routes-title">My Routes</div>
+        <div class="mob-routes-count">5 total</div>
+        <button class="mob-routes-close"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
+      </div>
+      <div class="mob-routes-list">
+        <div class="mob-route-item current">
+          <svg class="ico-sm mob-route-item-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+          <div class="route-item-glyph"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+          <div class="mob-route-item-info"><div class="mob-route-item-name">Pentland Skyline</div><div class="mob-route-item-meta">8.6 km · Just now</div></div>
+        </div>
+        <div class="mob-route-item">
+          <div style="width:15px;flex-shrink:0;"></div>
+          <div class="route-item-glyph"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+          <div class="mob-route-item-info"><div class="mob-route-item-name">Ridgeline Loop</div><div class="mob-route-item-meta">18.7 km · 2d ago</div></div>
+          <button class="mob-route-item-overflow"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+        </div>
+        <div class="mob-route-item">
+          <div style="width:15px;flex-shrink:0;"></div>
+          <div class="route-item-glyph"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+          <div class="mob-route-item-info"><div class="mob-route-item-name">Coastal Loop AM</div><div class="mob-route-item-meta">9.2 km · 6d ago</div></div>
+          <button class="mob-route-item-overflow"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+        </div>
+        <div class="mob-route-item">
+          <div style="width:15px;flex-shrink:0;"></div>
+          <div class="route-item-glyph"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+          <div class="mob-route-item-info"><div class="mob-route-item-name">Forth Bridge Out-and-Back</div><div class="mob-route-item-meta">24.1 km · 2w ago</div></div>
+          <button class="mob-route-item-overflow"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+        </div>
+        <div class="mob-route-item">
+          <div style="width:15px;flex-shrink:0;"></div>
+          <div class="route-item-glyph untitled"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+          <div class="mob-route-item-info"><div class="mob-route-item-name untitled">Untitled route</div><div class="mob-route-item-meta">3.1 km · 4h ago</div></div>
+          <button class="mob-route-item-overflow"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+        </div>
+      </div>
+      <div class="mob-routes-new"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>New Route</div>
+    </div>
+
+  </div></div>
+  <div class="frame-note">Same floating-card language as the existing activities/detail bottom sheet — tall snap, drag-free here since it's a picker rather than the persistent map sheet. Tapping a row loads that route into the editor and closes the sheet.</div>
+</div><!-- /frame 02 -->
+
+
+<!-- ════════════════════════════════════════
+     FRAME 03 · INLINE RENAME
+════════════════════════════════════════ -->
+<div class="frame-wrap">
+  <div class="frame-label">03 — Inline Rename</div>
+  <div class="frame-border"><div class="mob-frame">
+
+    <div class="mob-map">
+      <svg style="position:absolute;inset:0;width:100%;height:100%;" viewBox="0 0 390 844" preserveAspectRatio="xMidYMid slice">
+        <polyline points="118,620 140,590 165,558 188,524 208,490 222,454 230,416 234,378 232,340 226,304" fill="none" stroke="#E07020" stroke-width="6" stroke-opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>
+        <polyline points="118,620 140,590 165,558 188,524 208,490 222,454 230,416 234,378 232,340 226,304" fill="none" stroke="rgba(7,14,20,0.55)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </div>
+
+    <div class="mob-header">
+      <div class="mob-header-word">plot</div>
+      <div class="mob-header-sep"></div>
+      <div class="mob-tabs"><div class="mob-tab-indicator" style="left:78px;"></div><button class="mob-tab">Activities</button><button class="mob-tab active" style="left:78px;">Planner</button></div>
+      <div class="mob-header-sep"></div>
+      <div class="mob-avatar">PC</div>
+    </div>
+
+    <div class="mob-toolbar">
+      <button class="mob-tb-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 14 4 9l5-5"/><path d="M4 9h10.5a5.5 5.5 0 0 1 0 11H11"/></svg><span>Undo</span></button>
+      <button class="mob-tb-btn disabled"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14l5-5-5-5"/><path d="M20 9H9.5a5.5 5.5 0 0 0 0 11H13"/></svg><span>Redo</span></button>
+      <button class="mob-tb-btn active"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg><span>Add</span></button>
+      <button class="mob-tb-btn active"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg><span>Snap</span></button>
+      <button class="mob-tb-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg><span>Clear</span></button>
+      <button class="mob-tb-btn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3L21 7L17 11"/><path d="M3 7h18"/><path d="M7 21L3 17L7 13"/><path d="M21 17H3"/></svg><span>Rev.</span></button>
+    </div>
+
+    <div class="mob-hud" style="height:262px;">
+      <div class="mob-hud-handle-zone"><div class="mob-hud-handle"></div></div>
+
+      <div class="mob-hud-route">
+        <div class="mob-hud-route-glyph untitled"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M8 19h7a4 4 0 0 0 4-4v-1a4 4 0 0 0-4-4H9a4 4 0 0 1-4-4v-1"/></svg></div>
+        <input class="mob-route-name-input" value="Untitled route" style="background:rgba(224,112,32,0.12);">
+        <button class="mob-rename-confirm"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></button>
+      </div>
+      <div style="padding:0 16px 8px;font:400 8.5px/1.4 var(--mono);color:var(--fog-dim);letter-spacing:.03em;">Tap ✓ to save · tap elsewhere to cancel</div>
+      <div class="mob-hud-divider"></div>
+
+      <div class="mob-hud-stats">
+        <div class="mob-hud-stat"><div class="mob-hud-val">2.1</div><div class="mob-hud-lbl">km</div></div>
+        <div class="mob-hud-stat"><div class="mob-hud-val">40</div><div class="mob-hud-lbl">m elev</div></div>
+        <div class="mob-hud-stat"><div class="mob-hud-val">2</div><div class="mob-hud-lbl">waypts</div></div>
+      </div>
+      <div class="mob-hud-actions">
+        <button class="mob-hud-btn neutral"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>Import</button>
+        <button class="mob-hud-btn neutral"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>Image</button>
+        <button class="mob-hud-btn primary"><svg class="ico-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>Export</button>
+      </div>
+    </div>
+
+  </div></div>
+  <div class="frame-note">Tapping the route name (untitled or not) turns it into a focused input in place — no sheet, no modal. A small checkmark button confirms since there's no desktop-style Enter key to rely on.</div>
+</div><!-- /frame 03 -->
+
+
+<!-- ════════════════════════════════════════
+     FRAME 04 · ROUTE ACTIONS SHEET
+════════════════════════════════════════ -->
+<div class="frame-wrap">
+  <div class="frame-label">04 — Route Actions · Delete Confirm</div>
+  <div class="frame-border"><div class="mob-frame">
+
+    <div class="mob-map" style="opacity:0.4;"></div>
+    <div class="scrim"></div>
+
+    <div class="mob-routes-sheet" style="height:340px;opacity:0.35;">
+      <div class="mob-routes-hdr"><div class="mob-routes-title">My Routes</div><div class="mob-routes-count">5 total</div></div>
+    </div>
+
+    <!-- Compact actions sheet, overlaid above -->
+    <div class="mob-actions-sheet">
+      <div class="mob-hud-handle-zone"><div class="mob-hud-handle"></div></div>
+      <div class="mob-actions-hdr">
+        <div class="mob-actions-hdr-lbl">Route Actions</div>
+        <div class="mob-actions-hdr-name">Coastal Loop AM</div>
+      </div>
+      <div class="mob-action-row"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg><span>Rename</span></div>
+      <div class="mob-action-row"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg><span>Duplicate</span></div>
+      <div class="mob-action-row danger"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg><span>Delete</span></div>
+
+      <div class="storyboard-caption"><svg class="ico-xs" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>tapping Delete expands to</div>
+      <div class="confirm-card-inline">
+        <div class="confirm-card-title">Delete <strong>"Coastal Loop AM"</strong>? This can't be undone.</div>
+        <div class="confirm-card-actions">
+          <button class="confirm-btn cancel">Cancel</button>
+          <button class="confirm-btn delete">Delete</button>
+        </div>
+      </div>
+    </div>
+
+  </div></div>
+  <div class="frame-note">Reached from a route row's overflow button in the My Routes sheet. Delete expands in place into the same confirm pattern used on desktop — never a silent destructive tap.</div>
+</div><!-- /frame 04 -->
+
+</div><!-- /frames-row -->
+
+</body>
+</html>

--- a/mockup-saved-routes.md
+++ b/mockup-saved-routes.md
@@ -1,0 +1,48 @@
+# Saved Routes — interaction notes
+
+Companion notes to `mockup-saved-routes-desktop.html` and `mockup-saved-routes-mobile.html`. Premium-only feature; non-premium users see none of this (existing single-scratchpad planner behaviour is unchanged for them).
+
+**Important:** `mockup-saved-routes-mobile.html` deliberately does **not** reuse `mockup-h.html`'s mobile chrome (`.mob-sheet`, `.mob-ptb`, `.mob-hud` full-width bars, "NEW ROUTE" FAB). That design predates a rebuild to a floating-capsule language — `MobileHeader.tsx` (pill header), `PlannerToolbar.tsx` (floating toolbar pill), and the HUD block in `MapShell.tsx` (floating card, not edge-to-edge). The mobile mockup is grounded in those real components instead. `mockup-h.html` itself is unchanged by this work and is now stale on mobile — worth a note for whoever next touches it.
+
+## Core flow: create → autosave → name
+
+1. User places the first waypoint (desktop: click map; mobile: tap map with Add enabled, which is on by default).
+2. A route record is created immediately and silently — "Untitled route". No dialog, nothing blocks the user from continuing to plot.
+3. Every edit (waypoint add/move/remove, snap toggle, reverse) debounce-saves to the route record. The autosave chip shows the state: dim pulsing dot + "Saving…" while a write is in flight, solid green dot + "Saved" ~1s after the last edit settles (reuses the existing green "synced" dot convention from the status bar).
+4. The route's start point is reverse-geocoded in the background to fill the location subtitle (e.g. "Pentland Hills · Edinburgh"). Shows "Locating…" until resolved; failure just leaves it blank, never blocks saving.
+5. Naming is optional at every step. Click/tap the name to rename in place (desktop: click-to-edit with full-text selection, Enter/Esc; mobile: tap-to-edit with a checkmark confirm button since there's no Enter key).
+
+## My Routes picker
+
+- Desktop: a "My Routes" row sits directly under the Planner tab, always visible regardless of whether a route is loaded. Clicking it opens a flyout with the full list — clicking a row loads that route (replacing the current one, no confirm needed since the outgoing route already autosaved); a checkmark marks the currently-loaded route.
+- Mobile: the HUD's route-identity row is the trigger; tapping it (or its chevron) opens a full "My Routes" floating sheet — same visual language as the existing activities bottom sheet.
+- List rows show: name, distance, relative last-edited ("2d ago", "Just now"). "Untitled route" entries render dimmer to distinguish unnamed drafts from named routes at a glance.
+- `+ New route` is always the last row/action — creates a fresh Untitled route immediately (same silent-create behaviour as the core flow) and switches to it.
+- First-time premium users see an empty state: icon + "No saved routes yet" + "Start plotting to create one." No separate onboarding — the existing "Start New Route" CTA underneath does the same thing.
+
+## Rename / duplicate / delete
+
+- Reached via a route row's overflow ("⋯") button — not available for the currently-open route inline in the switcher trigger (that one renames via the header itself).
+- Delete always requires an explicit confirm ("Delete 'X'? This can't be undone." + Cancel/Delete) — never a silent destructive tap, matching the existing `window.confirm('Clear the entire route?')` pattern in the planner toolbar, just implemented as a proper in-context card instead of a browser confirm.
+- Duplicate creates a new named copy ("X (copy)") immediately in the library without switching to it, so the user can keep working on the original.
+- Deleting the currently-open route falls back to loading the next-most-recent route, or creates a fresh Untitled route if the library is now empty.
+
+## Undo / redo (durable, no dedicated UI)
+
+- Per the product decision, the undo/redo stack persists per route and survives reload — but this is invisible plumbing, not a new UI surface. The existing Undo/Redo buttons in the toolbar just keep working when a route is reopened, including after a browser refresh or switching away and back via My Routes.
+- No history timeline, no revision browser — explicitly out of scope for this feature.
+
+## Autosave chip states
+
+| State | Dot | Label |
+|---|---|---|
+| Idle / settled | solid green, glowing | "Saved" |
+| Write in flight | dim grey, pulsing | "Saving…" |
+
+Reuses the existing glowing-dot convention from the status bar's "synced" indicator — same color, same visual weight, so it reads as part of the established design language rather than a new pattern.
+
+## Open questions for implementation (not blocking design sign-off)
+
+- Exact reverse-geocoding source (Google Maps key already present in env, or reuse ORS behind `/api/route`) — see plan's Phase 2 notes.
+- Debounce timing for autosave writes to the backend (existing local autosave debounce is 500ms; a network-backed save likely wants a longer debounce or a distinct "local instant, remote debounced" two-tier save).
+- Whether `+ New route` should prompt to save/name the outgoing Untitled route, or just leave it in the library as-is (current design: leave it — autosave already covers it, no prompt needed).


### PR DESCRIPTION
## Summary
- Adds a "My Routes" library to the planner for premium users: named, persistent routes with autosave, durable undo/redo, and a reverse-geocoded location label. Free-tier planner behaviour is unchanged (single anonymous localStorage route, zero backend footprint).
- Rewrites undo/redo from full-state snapshots to an action log (`{actions, cursor}`, `lib/route-actions.ts`) so undo/redo never re-triggers the routing API and per-cursor state is an O(1) lookup rather than a replay on every render.
- Unifies persistence: the same `{actions, cursor, mapCenter, mapZoom}` shape is written to localStorage (free) or the backend (premium) — one format, two storage adapters (`lib/route-storage.ts`, `lib/saved-routes.ts`).
- New UI: `SavedRoutesPicker` (desktop switcher + flyout), `RouteListRows` (shared rows, portaled overflow menu/delete-confirm so they don't get clipped by the scroll container), `MobileRoutesSheet`, `DeleteRouteConfirm`.
- Bumps the mobile planner HUD's collapsed/expanded snap points (60/168 → 90/185) to fit the new route-identity row.

Backend companion changes (`plot-backend`, already committed to `main` and deployed): new `/routes` CRUD routes with per-athlete ownership checks, `saved_routes` D1 table, and a dedicated `plot-routes` R2 bucket for the action-log blob.

## Test plan
- [x] `npm run build` && `npm run lint` pass clean
- [x] Backend `tsc --noEmit` passes clean
- [x] Production D1 migration applied, R2 bucket created, backend deployed and `/health` verified
- [ ] Manual verification in browser: create/rename/undo-reload/duplicate/delete a saved route as a premium athlete
- [ ] Confirm non-premium session never hits `/api/routes*` (network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyiDY8iudoMUMtHxKKnrBJ