### PR TITLE
feat(mobile): add JWT-authed route endpoints for the iOS app

### DIFF
--- a/app/api/mobile/routes/[id]/route.ts
+++ b/app/api/mobile/routes/[id]/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getMobileBackendConfig } from '@/lib/mobile-auth';
+import { replayToCursor } from '@/lib/route-actions';
+import { buildTrackPoints, generateGpx, simplifyWaypoints } from '@/lib/gpx';
+import { routeExportName, type RouteDetail } from '@/lib/saved-routes';
+import type { Waypoint } from '@/lib/types';
+
+function boundingBox(points: Waypoint[]): [number, number, number, number] | null {
+  if (points.length === 0) return null;
+  let minLng = points[0].lng;
+  let minLat = points[0].lat;
+  let maxLng = points[0].lng;
+  let maxLat = points[0].lat;
+  for (const p of points) {
+    if (p.lng < minLng) minLng = p.lng;
+    if (p.lat < minLat) minLat = p.lat;
+    if (p.lng > maxLng) maxLng = p.lng;
+    if (p.lat > maxLat) maxLat = p.lat;
+  }
+  return [minLng, minLat, maxLng, maxLat];
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const backend = await getMobileBackendConfig(request);
+  if (!backend) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let route: RouteDetail;
+  try {
+    const res = await fetch(`${backend.url}/routes/${id}`, {
+      headers: {
+        Authorization: `Bearer ${backend.token}`,
+        'X-Athlete-Id': backend.athleteId,
+      },
+    });
+    if (!res.ok) {
+      return new NextResponse(null, { status: res.status });
+    }
+    route = await res.json();
+  } catch {
+    return new NextResponse(null, { status: 502 });
+  }
+
+  const { waypoints, segments } = replayToCursor(route.actions, route.cursor);
+  const trackPoints = buildTrackPoints(waypoints, segments);
+
+  if (request.nextUrl.searchParams.get('format') === 'gpx') {
+    const gpx = generateGpx(waypoints, segments, route.name);
+    return new NextResponse(gpx, {
+      headers: {
+        'Content-Type': 'application/gpx+xml',
+        'Content-Disposition': `attachment; filename="${routeExportName(route)}.gpx"`,
+      },
+    });
+  }
+
+  return NextResponse.json({
+    id: route.id,
+    name: route.name,
+    location: route.location,
+    distanceM: route.distanceM,
+    waypointCount: route.waypointCount,
+    createdAt: route.createdAt,
+    updatedAt: route.updatedAt,
+    waypoints: simplifyWaypoints(trackPoints, 100),
+    bbox: boundingBox(trackPoints),
+  });
+}

--- a/app/api/mobile/routes/route.ts
+++ b/app/api/mobile/routes/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getMobileBackendConfig } from '@/lib/mobile-auth';
+
+export async function GET(request: NextRequest) {
+  const backend = await getMobileBackendConfig(request);
+  if (!backend) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const res = await fetch(`${backend.url}/routes`, {
+      headers: {
+        Authorization: `Bearer ${backend.token}`,
+        'X-Athlete-Id': backend.athleteId,
+      },
+    });
+
+    if (!res.ok) {
+      return new NextResponse(null, { status: res.status });
+    }
+
+    return NextResponse.json(await res.json());
+  } catch {
+    return new NextResponse(null, { status: 502 });
+  }
+}

--- a/lib/gpx.ts
+++ b/lib/gpx.ts
@@ -89,7 +89,7 @@ function escapeXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
-function buildTrackPoints(
+export function buildTrackPoints(
   waypoints: Waypoint[],
   segments?: RouteSegment[]
 ): Waypoint[] {

--- a/lib/mobile-auth.ts
+++ b/lib/mobile-auth.ts
@@ -1,0 +1,32 @@
+import { jwtVerify } from 'jose';
+import type { NextRequest } from 'next/server';
+
+export interface MobileBackendConfig {
+  url: string;
+  token: string;
+  athleteId: string;
+}
+
+/**
+ * Resolves backend config for a mobile-app request, authenticated by the
+ * plot-backend-issued JWT (Strava login → Bearer token, see docs/DESIGN.md
+ * §4 "Mobile endpoint auth"). Returns null on any auth or config failure;
+ * callers should respond 401 without distinguishing the cause.
+ */
+export async function getMobileBackendConfig(request: NextRequest): Promise<MobileBackendConfig | null> {
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader?.startsWith('Bearer ')) return null;
+
+  const jwtSecret = process.env.JWT_SECRET;
+  const url = process.env.TILES_BACKEND_URL;
+  const token = process.env.TILES_BEARER_TOKEN;
+  if (!jwtSecret || !url || !token) return null;
+
+  try {
+    const { payload } = await jwtVerify(authHeader.slice(7), new TextEncoder().encode(jwtSecret));
+    if (typeof payload.athlete_id !== 'number') return null;
+    return { url, token, athleteId: String(payload.athlete_id) };
+  } catch {
+    return null;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@turf/helpers": "^7.3.4",
         "@vercel/analytics": "^1.6.1",
         "iron-session": "^8.0.4",
+        "jose": "^6.2.3",
         "leaflet": "^1.9.4",
         "leaflet.markercluster": "^1.5.3",
         "lucide-react": "^0.564.0",
@@ -5882,6 +5883,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@turf/helpers": "^7.3.4",
     "@vercel/analytics": "^1.6.1",
     "iron-session": "^8.0.4",
+    "jose": "^6.2.3",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "lucide-react": "^0.564.0",


### PR DESCRIPTION
## Summary
- Adds `GET /api/mobile/routes` and `GET /api/mobile/routes/[id]` — the mobile-facing API surface plot-ios (Phase 1) needs to list and fetch saved routes.
- Auth is the JWT already issued by plot-backend's Strava login flow (`Authorization: Bearer <jwt>`, verified via `jose` against `JWT_SECRET`), not a new static token. Keeps things multi-user-correct for free since the athlete id comes from the verified claim.
- Route detail replays the action log server-side (reusing `lib/route-actions.ts`) and returns a simplified track (≤100 pts) + bbox, or the full GPX via `?format=gpx` — mirrors the existing desktop export path rather than porting replay logic to Swift.

## Why
plot-ios's iOS app needs to show a user's saved routes and download geometry for offline use. Route content interpretation (action-log replay, GPX generation) already lives entirely in plotv2, so a plotv2 endpoint reuses it directly instead of duplicating that logic in a Workers/Swift codebase. Full rationale in plot-ios's `docs/DESIGN.md` (§4, "Mobile endpoint auth" / "Why the mobile API lives in plotv2").

**Requires**: `JWT_SECRET` set in Vercel prod env, matching plot-backend's deployed secret (added by Peter separately — not in this diff since it's a secret).

## Test plan
- [x] `npx tsc --noEmit` and `npm run build` pass
- [x] `npm run lint` clean on changed files
- [x] Smoke-tested locally against the live backend: 401 on missing/invalid auth, route list returns real summaries, route detail returns replayed waypoints + bbox, `?format=gpx` returns a valid GPX file with correct content-type/filename
- [ ] iOS app integration (Phase 1, in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uUcecCyDd8cJLPoXtSxLD