### PR TITLE
feat(mobile): sample DEM elevation + ascent for mobile route detail

### DIFF
--- a/app/(main)/planner/PlannerToolbar.tsx
+++ b/app/(main)/planner/PlannerToolbar.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom';
 import { ArrowUp, Undo2, Redo2, MapPinPlus, Link2, Trash2, Upload, Download, ArrowRightLeft, ChevronLeft } from 'lucide-react';
 import { RouteAction } from './useRouteHistory';
 import { downloadGpx, parseGpx, selectGpxWaypoints } from '@/lib/gpx';
+import { elevationGain } from '@/lib/elevation';
 import { Waypoint, RouteSegment } from '@/lib/types';
 import type { ElevationPoint } from './useElevationProfile';
 import ImportRoutePopover from '@/app/components/shell/ImportRoutePopover';
@@ -100,12 +101,7 @@ export default function PlannerToolbar({
 
   const elevGain = useMemo(() => {
     if (!elevationData || elevationData.length < 2) return null;
-    let gain = 0;
-    for (let i = 1; i < elevationData.length; i++) {
-      const delta = elevationData[i].ele - elevationData[i - 1].ele;
-      if (delta > 0) gain += delta;
-    }
-    return Math.round(gain);
+    return elevationGain(elevationData);
   }, [elevationData]);
 
   const handleUndo = useCallback(() => dispatch({ type: 'UNDO' }), [dispatch]);

--- a/app/api/elevation/route.ts
+++ b/app/api/elevation/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { fetchTerrElev, lngLatToTerrPx, sampleElevation } from '@/lib/dem';
+import { sampleElevationsForCoords } from '@/lib/dem';
 
 const MAX_COORDS = 2000;
-const TERR_Z = 13; // ≈11 m/px at UK latitudes — better than ORS SRTM ~30 m
-const TILE_SIZE = 256;
 
 /** Downsample a coordinate array to at most `max` points, always keeping first and last. */
 function downsample(coords: [number, number][], max: number): [number, number][] {
@@ -31,35 +29,9 @@ export async function POST(request: NextRequest) {
 
   try {
     const sampled = downsample(body.coordinates, MAX_COORDS);
-    const terrN = 1 << TERR_Z;
-
-    // Collect the distinct set of DEM tiles the polyline crosses, including bilinear neighbours
-    const tileSet = new Set<string>();
-    for (const [lng, lat] of sampled) {
-      const [px, py] = lngLatToTerrPx(lng, lat, terrN);
-      const tx = Math.floor(px / TILE_SIZE);
-      const ty = Math.floor(py / TILE_SIZE);
-      tileSet.add(`${tx},${ty}`);
-      tileSet.add(`${tx + 1},${ty}`);
-      tileSet.add(`${tx},${ty + 1}`);
-      tileSet.add(`${tx + 1},${ty + 1}`);
-    }
-
-    // Fetch all needed tiles in parallel (fetchTerrElev is module-level cache-backed)
-    const tileEntries = await Promise.all(
-      [...tileSet].map(async (k) => {
-        const [x, y] = k.split(',').map(Number);
-        const data = await fetchTerrElev(TERR_Z, x, y);
-        return [`${TERR_Z}/${x}/${y}`, data] as [string, Float32Array | null];
-      })
-    );
-    const tiles = new Map<string, Float32Array | null>(tileEntries);
-
-    const coordinates = sampled.map(([lng, lat]) => ({
-      lat,
-      lng,
-      ele: sampleElevation(lng, lat, TERR_Z, tiles),
-    }));
+    const points = sampled.map(([lng, lat]) => ({ lat, lng }));
+    const elevations = await sampleElevationsForCoords(points);
+    const coordinates = points.map((p, i) => ({ ...p, ele: elevations[i] }));
 
     return NextResponse.json(
       { coordinates },

--- a/app/api/mobile/routes/[id]/route.ts
+++ b/app/api/mobile/routes/[id]/route.ts
@@ -3,7 +3,11 @@ import { getMobileBackendConfig } from '@/lib/mobile-auth';
 import { replayToCursor } from '@/lib/route-actions';
 import { buildTrackPoints, generateGpx, simplifyWaypoints } from '@/lib/gpx';
 import { routeExportName, type RouteDetail } from '@/lib/saved-routes';
+import { sampleElevationsForCoords } from '@/lib/dem';
+import { elevationGain, smoothElevation } from '@/lib/elevation';
 import type { Waypoint } from '@/lib/types';
+
+const MAX_TRACK_POINTS = 1000;
 
 function boundingBox(points: Waypoint[]): [number, number, number, number] | null {
   if (points.length === 0) return null;
@@ -59,15 +63,27 @@ export async function GET(
     });
   }
 
+  // Routed segments carry no elevation (only manually-placed waypoints might) — sample the
+  // DEM ourselves, same pipeline the desktop elevation profile uses (see lib/dem.ts,
+  // lib/elevation.ts), so ascent reads consistently across web and mobile.
+  const simplified = simplifyWaypoints(trackPoints, MAX_TRACK_POINTS);
+  const elevations = await sampleElevationsForCoords(simplified);
+  const sampled = simplified.map((wp, i) => ({ ...wp, ele: elevations[i] }));
+  // Same smoothing window as the desktop elevation profile (useElevationProfile.ts),
+  // so ascent reads consistently between web and mobile.
+  const windowSize = Math.max(5, Math.round(sampled.length / 40));
+  const waypointsWithEle = smoothElevation(sampled, windowSize);
+
   return NextResponse.json({
     id: route.id,
     name: route.name,
     location: route.location,
     distanceM: route.distanceM,
+    ascentM: elevationGain(waypointsWithEle),
     waypointCount: route.waypointCount,
     createdAt: route.createdAt,
     updatedAt: route.updatedAt,
-    waypoints: simplifyWaypoints(trackPoints, 100),
+    waypoints: waypointsWithEle,
     bbox: boundingBox(trackPoints),
   });
 }

--- a/app/components/shell/MapShell.tsx
+++ b/app/components/shell/MapShell.tsx
@@ -23,6 +23,7 @@ import {
   displayRouteLabel, routeExportName, routeLabelStyle, UNTITLED_ROUTE_NAME, type RouteSummary,
 } from '@/lib/saved-routes';
 import { selectGpxWaypoints, downloadGpx, parseGpx } from '@/lib/gpx';
+import { elevationGain } from '@/lib/elevation';
 import { OS_PROJECTION } from '@/lib/map-config';
 import LeftPanel from './LeftPanel';
 import BrowsePanel from './BrowsePanel';
@@ -491,12 +492,7 @@ export default function MapShell({ activities, avatarInitials, isLoggedIn = fals
 
   const elevGain = useMemo(() => {
     if (!elevationData || elevationData.length < 2) return 0;
-    let gain = 0;
-    for (let i = 1; i < elevationData.length; i++) {
-      const delta = elevationData[i].ele - elevationData[i - 1].ele;
-      if (delta > 0) gain += delta;
-    }
-    return Math.round(gain);
+    return elevationGain(elevationData);
   }, [elevationData]);
 
   const [mobilePlannerLayersOpen, setMobilePlannerLayersOpen] = useState(false);

--- a/lib/dem.ts
+++ b/lib/dem.ts
@@ -71,3 +71,36 @@ export function sampleElevation(lng: number, lat: number, z: number, tiles: Map<
     sample(x0 + 1, y0 + 1) * fx       * fy
   );
 }
+
+export const DEFAULT_TERR_Z = 13; // ≈11 m/px at UK latitudes — better than ORS SRTM ~30 m
+
+/** Bilinearly sample elevation (meters) for each coordinate, fetching (and caching) only the DEM tiles they cross. */
+export async function sampleElevationsForCoords(
+  coords: { lat: number; lng: number }[],
+  z = DEFAULT_TERR_Z,
+): Promise<number[]> {
+  const terrN = 1 << z;
+
+  // Collect the distinct set of DEM tiles the polyline crosses, including bilinear neighbours
+  const tileSet = new Set<string>();
+  for (const { lng, lat } of coords) {
+    const [px, py] = lngLatToTerrPx(lng, lat, terrN);
+    const tx = Math.floor(px / TILE_SIZE);
+    const ty = Math.floor(py / TILE_SIZE);
+    tileSet.add(`${tx},${ty}`);
+    tileSet.add(`${tx + 1},${ty}`);
+    tileSet.add(`${tx},${ty + 1}`);
+    tileSet.add(`${tx + 1},${ty + 1}`);
+  }
+
+  const tileEntries = await Promise.all(
+    [...tileSet].map(async (k) => {
+      const [x, y] = k.split(',').map(Number);
+      const data = await fetchTerrElev(z, x, y);
+      return [`${z}/${x}/${y}`, data] as [string, Float32Array | null];
+    })
+  );
+  const tiles = new Map<string, Float32Array | null>(tileEntries);
+
+  return coords.map(({ lng, lat }) => sampleElevation(lng, lat, z, tiles));
+}

--- a/lib/elevation.ts
+++ b/lib/elevation.ts
@@ -21,10 +21,10 @@ export function haversineDistance(
   return R * 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
 }
 
-export function smoothElevation(
-  points: ElevationPoint[],
+export function smoothElevation<T extends { ele: number }>(
+  points: T[],
   windowSize: number
-): ElevationPoint[] {
+): T[] {
   if (points.length < windowSize * 2) return points;
   const half = Math.floor(windowSize / 2);
   return points.map((pt, i) => {
@@ -34,6 +34,17 @@ export function smoothElevation(
     for (let j = start; j <= end; j++) sum += points[j].ele;
     return { ...pt, ele: sum / (end - start + 1) };
   });
+}
+
+/** Total ascent (meters): sum of positive elevation deltas between consecutive points. */
+export function elevationGain(points: { ele: number }[]): number {
+  if (points.length < 2) return 0;
+  let gain = 0;
+  for (let i = 1; i < points.length; i++) {
+    const delta = points[i].ele - points[i - 1].ele;
+    if (delta > 0) gain += delta;
+  }
+  return Math.round(gain);
 }
 
 export function downsampleToChartPoints(


### PR DESCRIPTION
## Summary
- `GET /api/mobile/routes/[id]` now returns `ascentM` and elevation-enriched `waypoints` — routed segments carry no stored elevation, so the endpoint samples the Terrarium DEM itself. Bumped the simplified-track cap from 100 → 1000 points.
- Reuses the desktop planner's exact pipeline (DEM tile sampling, smoothing window, ascent-from-deltas) instead of a second implementation, so the number reads the same on web and mobile:
  - `lib/dem.ts`: extracted `sampleElevationsForCoords()` from `/api/elevation`'s inline tile-collection loop; that route now calls it too (behavior unchanged, verified via curl before/after).
  - `lib/elevation.ts`: extracted `elevationGain()` from the identical inline calc duplicated in `PlannerToolbar.tsx` and `MapShell.tsx` (pure refactor, same math, no UI behavior change); made `smoothElevation()` generic so the mobile endpoint can reuse it without the chart-only `distance` field.

## Why
This follow-up brings the mobile route endpoint (merged in #70) in line with the plot-ios Phase 1 execution plan, which specced DEM-sampled elevation + ascent as part of the route detail response — the initial PR shipped without it. Sharing the desktop's existing DEM/ascent code (rather than a parallel implementation) keeps the ascent figure consistent across platforms and avoids a third copy of logic that already existed twice.

## Test plan
- [x] `npx tsc --noEmit` and `npm run build` pass
- [x] `npm run lint` clean on changed files (pre-existing unrelated warnings only)
- [x] Smoke-tested locally against the live backend: route detail returns plausible `ascentM` and per-point elevations for a real route
- [x] `/api/elevation` re-tested after the `lib/dem.ts` refactor — identical output to before
- [ ] iOS app integration (Phase 1, in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uUcecCyDd8cJLPoXtSxLD