### PR TITLE
fix(mobile): proxy plot-backend's Strava OAuth under plot.fit

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,19 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  // Strava only accepts redirect_uris under this app's registered callback
+  // domain (plot.fit) — plot-backend's mobile Strava login lives on its own
+  // workers.dev domain, so its /auth/* routes are proxied here instead of
+  // the mobile app talking to plot-backend directly. See plot-backend's
+  // MOBILE_AUTH_PUBLIC_URL and plot-ios/docs/DESIGN.md.
+  async rewrites() {
+    return [
+      {
+        source: '/api/mobile/auth/:path*',
+        destination: 'https://plot-backend.hold-it.workers.dev/auth/:path*',
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -24,7 +24,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: '/api/mobile/auth/:path*',
-        destination: 'https://plot-backend.hold-it.workers.dev/auth/:path*',
+        destination: `${process.env.TILES_BACKEND_URL}/auth/:path*`,
       },
     ];
   },


### PR DESCRIPTION
## Summary
- Adds a rewrite so `/api/mobile/auth/*` transparently proxies to plot-backend's `/auth/*` (Strava OAuth kickoff + callback), landing the OAuth redirect under `plot.fit` instead of plot-backend's own `workers.dev` domain.

## Why
The iOS app's Strava login goes through plot-backend, but this Strava API app has only one registered Authorization Callback Domain (`plot.fit`, matching plotv2's existing web login) — Strava rejected any redirect_uri on plot-backend's workers.dev domain with a "bad request" error, which is exactly what broke the mobile login when first tested. Proxying under plot.fit avoids registering a second Strava app. Pairs with a companion fix in plot-backend (already pushed/deployed) that builds its Strava-facing redirect_uri from a fixed `MOBILE_AUTH_PUBLIC_URL` env var instead of deriving it from the incoming request.

See `plot-ios/docs/DESIGN.md` (§4, "Mobile endpoint auth") for the full design.

## Test plan
- [x] `npx tsc --noEmit` and `npm run build` pass
- [x] Verified locally: `curl http://localhost:3000/api/mobile/auth/strava?redirect_uri=plot://auth` correctly proxies to the (currently still old-code) deployed worker and returns its 302 unchanged
- [ ] End-to-end: once plot-backend's `MOBILE_AUTH_PUBLIC_URL` secret is set, confirm the redirect_uri sent to Strava is `https://plot.fit/api/mobile/auth/callback` and the iOS login flow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uUcecCyDd8cJLPoXtSxLD